### PR TITLE
Enable Github check workflow

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,0 +1,25 @@
+name: check
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ "*" ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: mount bazel cache
+      uses: actions/cache@v3
+      with:
+        path: "~/.cache/bazel"
+        key: bazel-test
+
+    - run: |
+        bazel \
+          --bazelrc=.github/workflows/ci.bazelrc \
+          test \
+          //...

--- a/.github/workflows/ci.bazelrc
+++ b/.github/workflows/ci.bazelrc
@@ -1,0 +1,11 @@
+# This is from Bazel's former travis setup, to avoid blowing up the RAM usage.
+startup --host_jvm_args=-Xmx2500m
+
+build --show_timestamps
+build --announce_rc
+build --color=yes
+build --terminal_columns=120
+build --remote_download_minimal
+
+test --test_output=all
+test --test_verbose_timeout_warnings

--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -5,10 +5,8 @@ BAZEL_BOOTLIN_COMMIT = "22ee91e01bbbc0711444c49102e92010fc6d6c95"
 http_archive(
     name = "bazel_bootlin",
     sha256 = "3acd4ebca797fb05db00b1ebcac831fa920f503dd611c255c7f80cfad944182e",
-    strip_prefix = "bazel_bootlin-{commit}".format(commit = BAZEL_BOOTLIN_COMMIT),
-    url = "https://github.com/oliverlee/bazel_bootlin/archive/{commit}.tar.gz".format(
-        commit = BAZEL_BOOTLIN_COMMIT,
-    ),
+    strip_prefix = "bazel_bootlin-%s" % BAZEL_BOOTLIN_COMMIT,
+    url = "https://github.com/oliverlee/bazel_bootlin/archive/%s.tar.gz" % BAZEL_BOOTLIN_COMMIT,
 )
 
 load("@bazel_bootlin//:defs.bzl", "bootlin_toolchain")
@@ -47,9 +45,7 @@ bootlin_toolchain(
     ],
 )
 
-register_toolchains(
-    "@{toolchain_name}//:toolchain".format(toolchain_name = "gcc_12_2_toolchain"),
-)
+register_toolchains("@gcc_12_2_toolchain//:toolchain")
 
 RULES_CUDA_VERSION = "v0.1.2"
 


### PR DESCRIPTION
Enable a pre-merge check workflow that verifies //:print_hip_info run
and that all tests pass.

This commit also fixes an incorrect commit for the @bazel_bootlin
dependency.

Change-Id: I9f00399c5aa33b52d332e4b05261dfb4869d565e