### PR TITLE
Add C++ format rules

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -6,4 +6,10 @@ build --action_env="BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1"
 build --flag_alias=cuda=@rules_cuda//cuda:enable
 build --cuda=false
 
+build:clang-format --aspects @bazel_clang_format//:defs.bzl%clang_format_aspect
+build:clang-format --@bazel_clang_format//:binary=@llvm_16_0_toolchain//:clang-format
+build:clang-format --@bazel_clang_format//:config=//:format_config
+build:clang-format --output_groups=report
+
 try-import %workspace%/user.bazelrc
+

--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,77 @@
+---
+BasedOnStyle: LLVM
+AlignAfterOpenBracket: Align
+AllowShortFunctionsOnASingleLine: Inline
+AllowShortIfStatementsOnASingleLine: false
+AllowShortBlocksOnASingleLine: Empty
+AllowShortLambdasOnASingleLine: All
+AllowShortLoopsOnASingleLine: true
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: false
+AlwaysBreakTemplateDeclarations: true
+BinPackArguments: false
+BinPackParameters: false
+BreakAfterAttributes: Always
+BreakBeforeBraces: Custom
+BraceWrapping:
+    AfterClass: true
+    AfterEnum: true
+    AfterFunction: true
+    AfterStruct: true
+    AfterUnion: true
+    SplitEmptyFunction: false
+    SplitEmptyRecord: false
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializers: BeforeColon
+BreakInheritanceList: BeforeColon
+BreakStringLiterals: true
+ColumnLimit: 80
+CompactNamespaces: false
+ConstructorInitializerAllOnOneLineOrOnePerLine: true
+Cpp11BracedListStyle: true
+DerivePointerAlignment: false
+FixNamespaceComments: true
+IncludeBlocks: Regroup
+IndentCaseLabels: true
+IndentWidth: 2
+InsertNewlineAtEOF: true
+Language: Cpp
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: None
+PenaltyIndentedWhitespace: 200
+PenaltyReturnTypeOnItsOwnLine: 1
+PointerAlignment: Left
+QualifierAlignment: Left
+ReflowComments: true
+SortIncludes: true
+SortUsingDeclarations: true
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeCtorInitializerColon: true
+SpaceBeforeInheritanceColon: true
+SpaceBeforeParens: Custom
+SpaceBeforeParensOptions:
+    AfterRequiresInClause: true
+    AfterRequiresInExpression: true
+SpaceBeforeRangeBasedForLoopColon: true
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 2
+SpacesInAngles: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+Standard: Latest
+
+IncludeCategories:
+  - Regex:           '"test'
+    Priority:        2
+  - Regex:           '"fmt'
+    Priority:        3
+  - Regex:           'metal.hpp'
+    Priority:        3
+  - Regex:           'boost/ut.hpp'
+    Priority:        4
+  - Regex:           '<[[:alnum:|_].]+>'
+    Priority:        5
+  - Regex:           '".*"'
+    Priority:        1
+
+...

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -23,3 +23,25 @@ jobs:
           --bazelrc=.github/workflows/ci.bazelrc \
           test \
           //...
+
+  clang-format:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: mount bazel cache
+      uses: actions/cache@v3
+      with:
+        path: "~/.cache/bazel"
+        key: bazel-clang-tidy
+
+    - name: install libtinfo5
+      # clang format links against this
+      run: sudo apt-get install -y libtinfo5
+
+    - run: |
+        bazel \
+          --bazelrc=.github/workflows/ci.bazelrc \
+          build \
+          --config clang-format \
+          //...

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,7 +1,20 @@
 load("@rules_cuda//cuda:defs.bzl", "cuda_library")
+load("@bazel_clang_format//:defs.bzl", "clang_format_update")
 load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
 
 package(default_visibility = ["//visibility:public"])
+
+filegroup(
+    name = "format_config",
+    srcs = [".clang-format"],
+    visibility = ["//visibility:public"],
+)
+
+clang_format_update(
+    name = "clang-format",
+    binary = "@llvm_16_0_toolchain//:clang-format",
+    config = ":format_config",
+)
 
 # TODO: won't be needed if https://github.com/bazel-contrib/rules_cuda/pull/99 is released
 genrule(

--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -131,3 +131,31 @@ cc_library(
     strip_prefix = "ut-%s" % BOOST_UT_VERSION,
     url = "https://github.com/boost-ext/ut/archive/%s.tar.gz" % BOOST_UT_VERSION,
 )
+
+BAZEL_TOOLCHAIN_VERSION = "41ff2a05c0beff439bad7acfd564e6827e34b13b"
+
+http_archive(
+    name = "bazel_toolchain",
+    sha256 = "52b09a61b9a03f4e0994402243a03018a858da6a5774de898f99e344520e9a25",
+    strip_prefix = "bazel-toolchain-%s" % BAZEL_TOOLCHAIN_VERSION,
+    url = "https://github.com/grailbio/bazel-toolchain/archive/%s.tar.gz" % BAZEL_TOOLCHAIN_VERSION,
+)
+
+load("@bazel_toolchain//toolchain:deps.bzl", "bazel_toolchain_dependencies")
+load("@bazel_toolchain//toolchain:rules.bzl", "llvm_toolchain")
+
+bazel_toolchain_dependencies()
+
+llvm_toolchain(
+    name = "llvm_16_0_toolchain",
+    llvm_version = "16.0.0",
+)
+
+BAZEL_CLANG_FORMAT_VERSION = "d1de0469f12f740d4b4884f88a5eff6e0245096c"
+
+http_archive(
+    name = "bazel_clang_format",
+    sha256 = "a90b76e346c67d7cea9939e02b87214fee0d6ac6aecb0af8294820ee08b31c1a",
+    strip_prefix = "bazel_clang_format-%s" % BAZEL_CLANG_FORMAT_VERSION,
+    url = "https://github.com/oliverlee/bazel_clang_format/archive/%s.tar.gz" % BAZEL_CLANG_FORMAT_VERSION,
+)

--- a/hip_info.cpp
+++ b/hip_info.cpp
@@ -2,9 +2,10 @@
  * Copyright (c) 2020 Advanced Micro Devices, Inc. All Rights Reserved.
  * See 'LICENSE' in the project root for license information.
  * -------------------------------------------------------------------------- */
-#include <iostream>
-#include <iomanip>
 #include "hip/hip_runtime.h"
+
+#include <iomanip>
+#include <iostream>
 
 #define KNRM "\x1B[0m"
 #define KRED "\x1B[31m"
@@ -15,172 +16,204 @@
 #define KCYN "\x1B[36m"
 #define KWHT "\x1B[37m"
 
-#define failed(...)                                                                                \
-    printf("%serror: ", KRED);                                                                     \
-    printf(__VA_ARGS__);                                                                           \
-    printf("\n");                                                                                  \
-    printf("error: TEST FAILED\n%s", KNRM);                                                        \
-    exit(EXIT_FAILURE);
+#define failed(...)                                                            \
+  printf("%serror: ", KRED);                                                   \
+  printf(__VA_ARGS__);                                                         \
+  printf("\n");                                                                \
+  printf("error: TEST FAILED\n%s", KNRM);                                      \
+  exit(EXIT_FAILURE);
 
-#define HIPCHECK(error)                                                                            \
-    if (error != hipSuccess) {                                                                     \
-        printf("%serror: '%s'(%d) at %s:%d%s\n", KRED, hipGetErrorString(error), error, __FILE__,  \
-               __LINE__, KNRM);                                                                    \
-        failed("API returned error code.");                                                        \
-    }
+#define HIPCHECK(error)                                                        \
+  if (error != hipSuccess) {                                                   \
+    printf(                                                                    \
+        "%serror: '%s'(%d) at %s:%d%s\n",                                      \
+        KRED,                                                                  \
+        hipGetErrorString(error),                                              \
+        error,                                                                 \
+        __FILE__,                                                              \
+        __LINE__,                                                              \
+        KNRM);                                                                 \
+    failed("API returned error code.");                                        \
+  }
 
-void printCompilerInfo() {
+void printCompilerInfo()
+{
 #ifdef __HCC__
-    printf("compiler: hcc version=%s, workweek (YYWWD) = %u\n", __hcc_version__, __hcc_workweek__);
+  printf(
+      "compiler: hcc version=%s, workweek (YYWWD) = %u\n",
+      __hcc_version__,
+      __hcc_workweek__);
 #endif
 #ifdef __NVCC__
-    printf("compiler: nvcc\n");
+  printf("compiler: nvcc\n");
 #endif
 }
 
-double bytesToKB(size_t s) { return (double)s / (1024.0); }
-double bytesToGB(size_t s) { return (double)s / (1024.0 * 1024.0 * 1024.0); }
+double bytesToKB(size_t s)
+{
+  return (double)s / (1024.0);
+}
+double bytesToGB(size_t s)
+{
+  return (double)s / (1024.0 * 1024.0 * 1024.0);
+}
 
-#define printLimit(w1, limit, units)                                                               \
-    {                                                                                              \
-        size_t val;                                                                                \
-        cudaDeviceGetLimit(&val, limit);                                                           \
-        std::cout << setw(w1) << #limit ": " << val << " " << units << std::endl;                  \
+#define printLimit(w1, limit, units)                                           \
+  {                                                                            \
+    size_t val;                                                                \
+    cudaDeviceGetLimit(&val, limit);                                           \
+    std::cout << setw(w1) << #limit ": " << val << " " << units << std::endl;  \
+  }
+
+void printDeviceProp(int deviceId)
+{
+  using namespace std;
+  const int w1 = 34;
+
+  cout << left;
+
+  cout << setw(w1)
+       << "--------------------------------------------------------------------"
+          "------------"
+       << endl;
+  cout << setw(w1) << "device#" << deviceId << endl;
+
+  hipDeviceProp_t props;
+  HIPCHECK(hipGetDeviceProperties(&props, deviceId));
+
+  cout << setw(w1) << "Name: " << props.name << endl;
+  cout << setw(w1) << "pciBusID: " << props.pciBusID << endl;
+  cout << setw(w1) << "pciDeviceID: " << props.pciDeviceID << endl;
+  cout << setw(w1) << "pciDomainID: " << props.pciDomainID << endl;
+  cout << setw(w1) << "multiProcessorCount: " << props.multiProcessorCount
+       << endl;
+  cout << setw(w1) << "maxThreadsPerMultiProcessor: "
+       << props.maxThreadsPerMultiProcessor << endl;
+  cout << setw(w1) << "isMultiGpuBoard: " << props.isMultiGpuBoard << endl;
+  cout << setw(w1) << "clockRate: " << (float)props.clockRate / 1000.0 << " Mhz"
+       << endl;
+  cout << setw(w1) << "memoryClockRate: "
+       << (float)props.memoryClockRate / 1000.0 << " Mhz" << endl;
+  cout << setw(w1) << "memoryBusWidth: " << props.memoryBusWidth << endl;
+  cout << setw(w1) << "clockInstructionRate: "
+       << (float)props.clockInstructionRate / 1000.0 << " Mhz" << endl;
+  cout << setw(w1) << "totalGlobalMem: " << fixed << setprecision(2)
+       << bytesToGB(props.totalGlobalMem) << " GB" << endl;
+  cout << setw(w1) << "maxSharedMemoryPerMultiProcessor: " << fixed
+       << setprecision(2) << bytesToKB(props.maxSharedMemoryPerMultiProcessor)
+       << " KB" << endl;
+  cout << setw(w1) << "totalConstMem: " << props.totalConstMem << endl;
+  cout << setw(w1) << "sharedMemPerBlock: "
+       << (float)props.sharedMemPerBlock / 1024.0 << " KB" << endl;
+  cout << setw(w1) << "canMapHostMemory: " << props.canMapHostMemory << endl;
+  cout << setw(w1) << "regsPerBlock: " << props.regsPerBlock << endl;
+  cout << setw(w1) << "warpSize: " << props.warpSize << endl;
+  cout << setw(w1) << "l2CacheSize: " << props.l2CacheSize << endl;
+  cout << setw(w1) << "computeMode: " << props.computeMode << endl;
+  cout
+      << setw(w1) << "maxThreadsPerBlock: " << props.maxThreadsPerBlock << endl;
+  cout << setw(w1) << "maxThreadsDim.x: " << props.maxThreadsDim[0] << endl;
+  cout << setw(w1) << "maxThreadsDim.y: " << props.maxThreadsDim[1] << endl;
+  cout << setw(w1) << "maxThreadsDim.z: " << props.maxThreadsDim[2] << endl;
+  cout << setw(w1) << "maxGridSize.x: " << props.maxGridSize[0] << endl;
+  cout << setw(w1) << "maxGridSize.y: " << props.maxGridSize[1] << endl;
+  cout << setw(w1) << "maxGridSize.z: " << props.maxGridSize[2] << endl;
+  cout << setw(w1) << "major: " << props.major << endl;
+  cout << setw(w1) << "minor: " << props.minor << endl;
+  cout << setw(w1) << "concurrentKernels: " << props.concurrentKernels << endl;
+  cout << setw(w1) << "cooperativeLaunch: " << props.cooperativeLaunch << endl;
+  cout << setw(w1) << "cooperativeMultiDeviceLaunch: "
+       << props.cooperativeMultiDeviceLaunch << endl;
+  cout << setw(w1) << "arch.hasGlobalInt32Atomics: "
+       << props.arch.hasGlobalInt32Atomics << endl;
+  cout << setw(w1) << "arch.hasGlobalFloatAtomicExch: "
+       << props.arch.hasGlobalFloatAtomicExch << endl;
+  cout << setw(w1) << "arch.hasSharedInt32Atomics: "
+       << props.arch.hasSharedInt32Atomics << endl;
+  cout << setw(w1) << "arch.hasSharedFloatAtomicExch: "
+       << props.arch.hasSharedFloatAtomicExch << endl;
+  cout << setw(w1) << "arch.hasFloatAtomicAdd: " << props.arch.hasFloatAtomicAdd
+       << endl;
+  cout << setw(w1) << "arch.hasGlobalInt64Atomics: "
+       << props.arch.hasGlobalInt64Atomics << endl;
+  cout << setw(w1) << "arch.hasSharedInt64Atomics: "
+       << props.arch.hasSharedInt64Atomics << endl;
+  cout << setw(w1) << "arch.hasDoubles: " << props.arch.hasDoubles << endl;
+  cout << setw(w1) << "arch.hasWarpVote: " << props.arch.hasWarpVote << endl;
+  cout
+      << setw(w1) << "arch.hasWarpBallot: " << props.arch.hasWarpBallot << endl;
+  cout << setw(w1) << "arch.hasWarpShuffle: " << props.arch.hasWarpShuffle
+       << endl;
+  cout << setw(w1) << "arch.hasFunnelShift: " << props.arch.hasFunnelShift
+       << endl;
+  cout << setw(w1) << "arch.hasThreadFenceSystem: "
+       << props.arch.hasThreadFenceSystem << endl;
+  cout << setw(w1) << "arch.hasSyncThreadsExt: " << props.arch.hasSyncThreadsExt
+       << endl;
+  cout << setw(w1) << "arch.hasSurfaceFuncs: " << props.arch.hasSurfaceFuncs
+       << endl;
+  cout << setw(w1) << "arch.has3dGrid: " << props.arch.has3dGrid << endl;
+  cout << setw(w1) << "arch.hasDynamicParallelism: "
+       << props.arch.hasDynamicParallelism << endl;
+  cout << setw(w1) << "gcnArch: " << props.gcnArch << endl;
+  cout << setw(w1) << "isIntegrated: " << props.integrated << endl;
+  cout << setw(w1) << "maxTexture1D: " << props.maxTexture1D << endl;
+  cout << setw(w1) << "maxTexture2D.width: " << props.maxTexture2D[0] << endl;
+  cout << setw(w1) << "maxTexture2D.height: " << props.maxTexture2D[1] << endl;
+  cout << setw(w1) << "maxTexture3D.width: " << props.maxTexture3D[0] << endl;
+  cout << setw(w1) << "maxTexture3D.height: " << props.maxTexture3D[1] << endl;
+  cout << setw(w1) << "maxTexture3D.depth: " << props.maxTexture3D[2] << endl;
+
+  int deviceCnt;
+  hipGetDeviceCount(&deviceCnt);
+  cout << setw(w1) << "peers: ";
+  for (int i = 0; i < deviceCnt; i++) {
+    int isPeer;
+    hipDeviceCanAccessPeer(&isPeer, i, deviceId);
+    if (isPeer) {
+      cout << "device#" << i << " ";
     }
-
-void printDeviceProp(int deviceId) {
-    using namespace std;
-    const int w1 = 34;
-
-    cout << left;
-
-    cout << setw(w1)
-         << "--------------------------------------------------------------------------------"
-         << endl;
-    cout << setw(w1) << "device#" << deviceId << endl;
-
-    hipDeviceProp_t props;
-    HIPCHECK(hipGetDeviceProperties(&props, deviceId));
-
-    cout << setw(w1) << "Name: " << props.name << endl;
-    cout << setw(w1) << "pciBusID: " << props.pciBusID << endl;
-    cout << setw(w1) << "pciDeviceID: " << props.pciDeviceID << endl;
-    cout << setw(w1) << "pciDomainID: " << props.pciDomainID << endl;
-    cout << setw(w1) << "multiProcessorCount: " << props.multiProcessorCount << endl;
-    cout << setw(w1) << "maxThreadsPerMultiProcessor: " << props.maxThreadsPerMultiProcessor
-         << endl;
-    cout << setw(w1) << "isMultiGpuBoard: " << props.isMultiGpuBoard << endl;
-    cout << setw(w1) << "clockRate: " << (float)props.clockRate / 1000.0 << " Mhz" << endl;
-    cout << setw(w1) << "memoryClockRate: " << (float)props.memoryClockRate / 1000.0 << " Mhz"
-         << endl;
-    cout << setw(w1) << "memoryBusWidth: " << props.memoryBusWidth << endl;
-    cout << setw(w1) << "clockInstructionRate: " << (float)props.clockInstructionRate / 1000.0
-         << " Mhz" << endl;
-    cout << setw(w1) << "totalGlobalMem: " << fixed << setprecision(2)
-         << bytesToGB(props.totalGlobalMem) << " GB" << endl;
-    cout << setw(w1) << "maxSharedMemoryPerMultiProcessor: " << fixed << setprecision(2)
-         << bytesToKB(props.maxSharedMemoryPerMultiProcessor) << " KB" << endl;
-    cout << setw(w1) << "totalConstMem: " << props.totalConstMem << endl;
-    cout << setw(w1) << "sharedMemPerBlock: " << (float)props.sharedMemPerBlock / 1024.0 << " KB"
-         << endl;
-    cout << setw(w1) << "canMapHostMemory: " << props.canMapHostMemory << endl;
-    cout << setw(w1) << "regsPerBlock: " << props.regsPerBlock << endl;
-    cout << setw(w1) << "warpSize: " << props.warpSize << endl;
-    cout << setw(w1) << "l2CacheSize: " << props.l2CacheSize << endl;
-    cout << setw(w1) << "computeMode: " << props.computeMode << endl;
-    cout << setw(w1) << "maxThreadsPerBlock: " << props.maxThreadsPerBlock << endl;
-    cout << setw(w1) << "maxThreadsDim.x: " << props.maxThreadsDim[0] << endl;
-    cout << setw(w1) << "maxThreadsDim.y: " << props.maxThreadsDim[1] << endl;
-    cout << setw(w1) << "maxThreadsDim.z: " << props.maxThreadsDim[2] << endl;
-    cout << setw(w1) << "maxGridSize.x: " << props.maxGridSize[0] << endl;
-    cout << setw(w1) << "maxGridSize.y: " << props.maxGridSize[1] << endl;
-    cout << setw(w1) << "maxGridSize.z: " << props.maxGridSize[2] << endl;
-    cout << setw(w1) << "major: " << props.major << endl;
-    cout << setw(w1) << "minor: " << props.minor << endl;
-    cout << setw(w1) << "concurrentKernels: " << props.concurrentKernels << endl;
-    cout << setw(w1) << "cooperativeLaunch: " << props.cooperativeLaunch << endl;
-    cout << setw(w1) << "cooperativeMultiDeviceLaunch: " << props.cooperativeMultiDeviceLaunch << endl;
-    cout << setw(w1) << "arch.hasGlobalInt32Atomics: " << props.arch.hasGlobalInt32Atomics << endl;
-    cout << setw(w1) << "arch.hasGlobalFloatAtomicExch: " << props.arch.hasGlobalFloatAtomicExch
-         << endl;
-    cout << setw(w1) << "arch.hasSharedInt32Atomics: " << props.arch.hasSharedInt32Atomics << endl;
-    cout << setw(w1) << "arch.hasSharedFloatAtomicExch: " << props.arch.hasSharedFloatAtomicExch
-         << endl;
-    cout << setw(w1) << "arch.hasFloatAtomicAdd: " << props.arch.hasFloatAtomicAdd << endl;
-    cout << setw(w1) << "arch.hasGlobalInt64Atomics: " << props.arch.hasGlobalInt64Atomics << endl;
-    cout << setw(w1) << "arch.hasSharedInt64Atomics: " << props.arch.hasSharedInt64Atomics << endl;
-    cout << setw(w1) << "arch.hasDoubles: " << props.arch.hasDoubles << endl;
-    cout << setw(w1) << "arch.hasWarpVote: " << props.arch.hasWarpVote << endl;
-    cout << setw(w1) << "arch.hasWarpBallot: " << props.arch.hasWarpBallot << endl;
-    cout << setw(w1) << "arch.hasWarpShuffle: " << props.arch.hasWarpShuffle << endl;
-    cout << setw(w1) << "arch.hasFunnelShift: " << props.arch.hasFunnelShift << endl;
-    cout << setw(w1) << "arch.hasThreadFenceSystem: " << props.arch.hasThreadFenceSystem << endl;
-    cout << setw(w1) << "arch.hasSyncThreadsExt: " << props.arch.hasSyncThreadsExt << endl;
-    cout << setw(w1) << "arch.hasSurfaceFuncs: " << props.arch.hasSurfaceFuncs << endl;
-    cout << setw(w1) << "arch.has3dGrid: " << props.arch.has3dGrid << endl;
-    cout << setw(w1) << "arch.hasDynamicParallelism: " << props.arch.hasDynamicParallelism << endl;
-    cout << setw(w1) << "gcnArch: " << props.gcnArch << endl;
-    cout << setw(w1) << "isIntegrated: " << props.integrated << endl;
-    cout << setw(w1) << "maxTexture1D: " << props.maxTexture1D << endl;
-    cout << setw(w1) << "maxTexture2D.width: " << props.maxTexture2D[0] << endl;
-    cout << setw(w1) << "maxTexture2D.height: " << props.maxTexture2D[1] << endl;
-    cout << setw(w1) << "maxTexture3D.width: " << props.maxTexture3D[0] << endl;
-    cout << setw(w1) << "maxTexture3D.height: " << props.maxTexture3D[1] << endl;
-    cout << setw(w1) << "maxTexture3D.depth: " << props.maxTexture3D[2] << endl;
-
-    int deviceCnt;
-    hipGetDeviceCount(&deviceCnt);
-    cout << setw(w1) << "peers: ";
-    for (int i = 0; i < deviceCnt; i++) {
-        int isPeer;
-        hipDeviceCanAccessPeer(&isPeer, i, deviceId);
-        if (isPeer) {
-            cout << "device#" << i << " ";
-        }
+  }
+  cout << endl;
+  cout << setw(w1) << "non-peers: ";
+  for (int i = 0; i < deviceCnt; i++) {
+    int isPeer;
+    hipDeviceCanAccessPeer(&isPeer, i, deviceId);
+    if (!isPeer) {
+      cout << "device#" << i << " ";
     }
-    cout << endl;
-    cout << setw(w1) << "non-peers: ";
-    for (int i = 0; i < deviceCnt; i++) {
-        int isPeer;
-        hipDeviceCanAccessPeer(&isPeer, i, deviceId);
-        if (!isPeer) {
-            cout << "device#" << i << " ";
-        }
-    }
-    cout << endl;
-
+  }
+  cout << endl;
 
 #ifdef __HIP_PLATFORM_NVCC__
-    // Limits:
-    cout << endl;
-    printLimit(w1, cudaLimitStackSize, "bytes/thread");
-    printLimit(w1, cudaLimitPrintfFifoSize, "bytes/device");
-    printLimit(w1, cudaLimitMallocHeapSize, "bytes/device");
-    printLimit(w1, cudaLimitDevRuntimeSyncDepth, "grids");
-    printLimit(w1, cudaLimitDevRuntimePendingLaunchCount, "launches");
+  // Limits:
+  cout << endl;
+  printLimit(w1, cudaLimitStackSize, "bytes/thread");
+  printLimit(w1, cudaLimitPrintfFifoSize, "bytes/device");
+  printLimit(w1, cudaLimitMallocHeapSize, "bytes/device");
+  printLimit(w1, cudaLimitDevRuntimeSyncDepth, "grids");
+  printLimit(w1, cudaLimitDevRuntimePendingLaunchCount, "launches");
 #endif
 
+  cout << endl;
 
-    cout << endl;
+  size_t free, total;
+  hipMemGetInfo(&free, &total);
 
-
-    size_t free, total;
-    hipMemGetInfo(&free, &total);
-
-    cout << fixed << setprecision(2);
-    cout << setw(w1) << "memInfo.total: " << bytesToGB(total) << " GB" << endl;
-    cout << setw(w1) << "memInfo.free:  " << bytesToGB(free) << " GB (" << setprecision(0)
-         << (float)free / total * 100.0 << "%)" << endl;
+  cout << fixed << setprecision(2);
+  cout << setw(w1) << "memInfo.total: " << bytesToGB(total) << " GB" << endl;
+  cout << setw(w1) << "memInfo.free:  " << bytesToGB(free) << " GB ("
+       << setprecision(0) << (float)free / total * 100.0 << "%)" << endl;
 }
 
+void printDeviceProps()
+{
+  int deviceCnt;
 
-void printDeviceProps() {
-    int deviceCnt;
+  HIPCHECK(hipGetDeviceCount(&deviceCnt));
 
-    HIPCHECK(hipGetDeviceCount(&deviceCnt));
-
-    for (int i = 0; i < deviceCnt; i++) {
-        hipSetDevice(i);
-        printDeviceProp(i);
-    }
+  for (int i = 0; i < deviceCnt; i++) {
+    hipSetDevice(i);
+    printDeviceProp(i);
+  }
 }

--- a/print_hip_info.cpp
+++ b/print_hip_info.cpp
@@ -1,13 +1,14 @@
-#include <iostream>
 #include "hip_info.hpp"
+
+#include <iostream>
 
 auto main() -> int
 {
-    std::cout << '\n';
+  std::cout << '\n';
 
-    printCompilerInfo();
+  printCompilerInfo();
 
-    printDeviceProps();
+  printDeviceProps();
 
-    std::cout << '\n';
+  std::cout << '\n';
 }

--- a/src/decompress.hpp
+++ b/src/decompress.hpp
@@ -1,25 +1,27 @@
 #pragma once
 
 #include <cstddef>
-#include <memory>
 #include <expected>
+#include <memory>
 #include <span>
 #include <vector>
 
 namespace gpu_deflate {
 
 // error code enum
-enum class Error : std::uint8_t {
-    Error,
+enum class Error : std::uint8_t
+{
+  Error,
 };
 
 // Inspired by https://docs.python.org/3/library/zlib.html#zlib.decompress
 template <std::size_t N, class ByteAllocator = std::allocator<std::byte>>
-std::expected<std::vector<std::byte>, Error> decompress(std::span<const std::byte, N> compressed, ByteAllocator alloc = {})
+std::expected<std::vector<std::byte>, Error>
+decompress(std::span<const std::byte, N> compressed, ByteAllocator alloc = {})
 {
-    (void) compressed;
-    auto decompressed = std::vector<std::byte, ByteAllocator>(alloc);
-    return decompressed;
+  (void)compressed;
+  auto decompressed = std::vector<std::byte, ByteAllocator>(alloc);
+  return decompressed;
 }
 
-}
+}  // namespace gpu_deflate

--- a/src/decompress_test.cpp
+++ b/src/decompress_test.cpp
@@ -1,5 +1,6 @@
 #include "decompress.hpp"
 
-int main() {
+int main()
+{
   return 0;
 }

--- a/toolchain/std_execution_available.cpp
+++ b/toolchain/std_execution_available.cpp
@@ -1,14 +1,15 @@
-#include <iostream>
-#include <ranges>
-#include <numeric>
 #include <execution>
+#include <iostream>
+#include <numeric>
+#include <ranges>
 
 auto main() -> int
 {
   constexpr auto iv = std::views::iota(1, 10);
 
   std::cout
-    << "parallel transform reduce: "
-    << std::transform_reduce(std::execution::par, iv.begin(), iv.end(), iv.begin(), 0)
-    << '\n';
+      << "parallel transform reduce: "
+      << std::transform_reduce(
+             std::execution::par, iv.begin(), iv.end(), iv.begin(), 0)
+      << '\n';
 }


### PR DESCRIPTION
Pull in @bazel_clang_format and @bazel_toolchain to allow use of
clang-format with a hermetic toolchain. This commit also adds a format
job to the check workflow.

To apply formatting to C/C++ source files, run

  bazel run //:clang-format

Change-Id: I5f9c599cdb6b2ad9435728b6bb5f31cb2e61eebe