### PR TITLE
Add Bazel file format/lint rules

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -45,3 +45,20 @@ jobs:
           build \
           --config clang-format \
           //...
+
+  buildifier:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: mount bazel cache
+      uses: actions/cache@v3
+      with:
+        path: "~/.cache/bazel"
+        key: bazel-buildifier
+
+    - run: |
+        bazel \
+          --bazelrc=.github/workflows/ci.bazelrc \
+          run \
+          //:buildifier.check

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,5 +1,6 @@
 load("@rules_cuda//cuda:defs.bzl", "cuda_library")
 load("@bazel_clang_format//:defs.bzl", "clang_format_update")
+load("@buildifier_prebuilt//:rules.bzl", "buildifier")
 load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
 
 package(default_visibility = ["//visibility:public"])
@@ -14,6 +15,18 @@ clang_format_update(
     name = "clang-format",
     binary = "@llvm_16_0_toolchain//:clang-format",
     config = ":format_config",
+)
+
+buildifier(
+    name = "buildifier.check",
+    lint_mode = "warn",
+    mode = "check",
+)
+
+buildifier(
+    name = "buildifier.fix",
+    lint_mode = "warn",
+    mode = "fix",
 )
 
 # TODO: won't be needed if https://github.com/bazel-contrib/rules_cuda/pull/99 is released

--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -159,3 +159,24 @@ http_archive(
     strip_prefix = "bazel_clang_format-%s" % BAZEL_CLANG_FORMAT_VERSION,
     url = "https://github.com/oliverlee/bazel_clang_format/archive/%s.tar.gz" % BAZEL_CLANG_FORMAT_VERSION,
 )
+
+http_archive(
+    name = "buildifier_prebuilt",
+    sha256 = "e46c16180bc49487bfd0f1ffa7345364718c57334fa0b5b67cb5f27eba10f309",
+    strip_prefix = "buildifier-prebuilt-6.1.0",
+    urls = [
+        "https://github.com/keith/buildifier-prebuilt/archive/6.1.0.tar.gz",
+    ],
+)
+
+load("@buildifier_prebuilt//:deps.bzl", "buildifier_prebuilt_deps")
+
+buildifier_prebuilt_deps()
+
+load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
+
+bazel_skylib_workspace()
+
+load("@buildifier_prebuilt//:defs.bzl", "buildifier_prebuilt_register_toolchains")
+
+buildifier_prebuilt_register_toolchains()

--- a/third_party/hip.BUILD.bazel
+++ b/third_party/hip.BUILD.bazel
@@ -1,3 +1,4 @@
+# buildifier: disable=module-docstring
 cc_library(
     name = "hip",
     hdrs = glob(["include/hip/*.h"]) + ["include/hip/hip_version.h"],

--- a/third_party/hip_cpu.BUILD.bazel
+++ b/third_party/hip_cpu.BUILD.bazel
@@ -1,3 +1,4 @@
+# buildifier: disable=module-docstring
 cc_library(
     name = "hip_cpu",
     srcs = glob([

--- a/third_party/hipamd.BUILD.bazel
+++ b/third_party/hipamd.BUILD.bazel
@@ -1,3 +1,4 @@
+# buildifier: disable=module-docstring
 cc_library(
     name = "hipamd",
     hdrs = glob(["include/**/*.h"]),

--- a/third_party/system_libs_linux_x86_64.BUILD.bazel
+++ b/third_party/system_libs_linux_x86_64.BUILD.bazel
@@ -1,3 +1,4 @@
+# buildifier: disable=module-docstring
 load("@rules_cc//cc:defs.bzl", "cc_import", "cc_library")
 
 cc_import(


### PR DESCRIPTION
Pull in @buildifier_prebuilt to check format/lint rules. This commit
adds a buildifier job to the check workflow.

To apply formatting to Bazel files, run

  bazel run //:buildifier.fix

Change-Id: Ia20b8ca1eb2d92722014eb84d313df2a8859538d