### PR TITLE
build with "-march=native"

### DIFF
--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -22,6 +22,7 @@ bootlin_toolchain(
     buildroot_version = "2022.08-1_bleeding",
     extra_cxxflags = [
         "-std=c++23",
+        "-march=native",
         "-fdiagnostics-color=always",
         "-Werror",
         "-Wall",


### PR DESCRIPTION
We're going for speed, not portability :-)