### PR TITLE
Allow statically sized storage for `code_table`s

### DIFF
--- a/src/detail/huffman_storage.hpp
+++ b/src/detail/huffman_storage.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <array>
 #include <cassert>
 #include <cstddef>
 #include <span>
@@ -7,27 +8,49 @@
 
 namespace gpu_deflate::detail {
 
-template <class intrusive_node, std::size_t Extent>
-class huffman_storage : std::vector<intrusive_node>
-{
-  static_assert(Extent == std::dynamic_extent, "not yet implemented");
+template <class Node, std::size_t Extent>
+using huffman_storage_base_t = std::conditional_t<
+    Extent == std::dynamic_extent,
+    std::vector<Node>,
+    std::array<Node, Extent>>;
 
+template <class Node, std::size_t Extent>
+class huffman_storage : huffman_storage_base_t<Node, Extent>
+{
 public:
-  using base_type = std::vector<intrusive_node>;
+  using base_type = huffman_storage_base_t<Node, Extent>;
+  using symbol_type = typename Node::symbol_type;
 
   template <class R>
-  huffman_storage(
-      const R& frequencies, typename intrusive_node::symbol_type eot)
-      : base_type{}
+    requires (Extent == std::dynamic_extent)
+  huffman_storage(const R& frequencies, symbol_type eot) : base_type{}
   {
     base_type::reserve(frequencies.size() + 1UZ);  // +1 for EOT
     base_type::emplace_back(eot, 1UZ);
 
     for (auto [symbol, freq] : frequencies) {
+      assert(symbol != eot and "`eot` cannot be a symbol in `frequencies``");
+      assert(freq and "the frequency for a symbol must be positive");
+
+      base_type::emplace_back(symbol, freq);
+    }
+  }
+
+  template <class R>
+    requires (Extent != std::dynamic_extent)
+  huffman_storage(const R& frequencies, symbol_type eot)
+      : base_type{{{eot, 1UZ}}}
+  {
+    assert(frequencies.size() + 1UZ == Extent);
+
+    auto& base = static_cast<base_type&>(*this);
+    auto i = std::size_t{};
+
+    for (auto [symbol, freq] : frequencies) {
       assert(symbol != eot);
       assert(freq);
 
-      base_type::emplace_back(symbol, freq);
+      base[++i] = {symbol, freq};
     }
   }
 

--- a/src/test/huffman_bench.cpp
+++ b/src/test/huffman_bench.cpp
@@ -1,6 +1,7 @@
 #include "src/huffman.hpp"
 #include "src/version/version.hpp"
 
+#include <array>
 #include <benchmark/benchmark.h>
 
 namespace {
@@ -8,12 +9,12 @@ namespace {
 void BM_CodeTable(benchmark::State& state)
 {
   const auto frequencies = std::vector<std::pair<char, std::size_t>>{
-      {'e', 100}, {'n', 20}, {'x', 1}, {'i', 40}, {'q', 3}};
+      {{'e', 100}, {'n', 20}, {'x', 1}, {'i', 40}, {'q', 3}}};
   constexpr auto eot = char{4};
 
   state.SetLabel(gpu_deflate::Version::full_version_string);
   for (auto _ : state) {
-    gpu_deflate::code_table ct{frequencies, eot};
+    auto ct = gpu_deflate::code_table<char, 6>{frequencies, eot};
     benchmark::DoNotOptimize(ct);
   }
 }


### PR DESCRIPTION
If specified with a static extent, use `std::array` as the underlying
storage of a `code_table`, allowing it to be statically sized. This
commit also defines deduction guides to deduce the static size from an
input range.

Change-Id: I742cecd16c55e9d4be53d9d89b8096052685e215