### PR TITLE
Construct a `code_table` from a symbol sequence

### DIFF
--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -22,7 +22,6 @@ COMMON_CXX_WARNINGS = [
     "-Wextra",
     "-Wpedantic",
     "-Wconversion",
-    "-Wshadow",
     "-Wnon-virtual-dtor",
     "-Wold-style-cast",
     "-Wcast-align",
@@ -48,6 +47,7 @@ bootlin_toolchain(
         "-Wduplicated-branches",
         "-Wlogical-op",
         "-Wuseless-cast",
+        "-Wshadow=compatible-local",  # Equivalent to -Wshadow on llvm. GCC default is stupid.
     ] + COMMON_CXX_FLAGS + COMMON_CXX_WARNINGS,
 )
 
@@ -71,6 +71,7 @@ llvm_toolchain(
         "": [
             "-stdlib=libc++",
             "-std=c++2b",
+            "-Wshadow",
         ] + COMMON_CXX_FLAGS + COMMON_CXX_WARNINGS,
     },
     # Link UBSan C++ runtime libraries if the `ubsan` feature is enabled

--- a/src/test/huffman.cpp
+++ b/src/test/huffman.cpp
@@ -140,4 +140,26 @@ auto main() -> int
     static_assert(CodePoint{'q', 4UZ, 1UZ} == table.begin()[2]);
     static_assert(CodePoint{'x', 5UZ, 1UZ} == table.begin()[1]);
   };
+
+  test("code table constructible from symbol sequence") = [] {
+    const auto frequencies = std::vector<std::pair<char, std::size_t>>{
+        {'e', 100}, {'n', 20}, {'x', 1}, {'i', 40}, {'q', 3}};
+
+    const auto data = [&frequencies] {
+      auto d = std::vector<char>{};
+
+      for (auto [s, n] : frequencies) {
+        d.insert(d.cend(), n, s);
+      }
+
+      return d;
+    }();
+
+    constexpr auto eot = char{4};
+
+    const auto t1 = gpu_deflate::code_table{frequencies, eot};
+    const auto t2 = gpu_deflate::code_table{data, eot};
+
+    expect(std::ranges::equal(t1, t2));
+  };
 }


### PR DESCRIPTION
Allow construction of a `code_table` from an input range of symbols.
This is currently supported only for `code_table` types with dynamic
extent.

Change-Id: Ied4e27547d144995b692520ea879761b7b9e2691