### PR TITLE
Allow excess capacity for static extent `code_table`s

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -25,6 +25,9 @@ Checks: >
     # C-arrays necessary as function args,
     -modernize-avoid-c-arrays,
 
+    # use iterators as abstractions, not pointers,
+    -readability-qualified-auto,
+
     # false positive with spaceship operator,
     # https://reviews.llvm.org/D95714?id=320393,
     -modernize-use-nullptr,

--- a/src/huffman.hpp
+++ b/src/huffman.hpp
@@ -345,12 +345,12 @@ public:
 
   template <std::ranges::input_range R>
     requires std::convertible_to<std::ranges::range_reference_t<R>, symbol_type>
-  explicit code_table(const R& data) : code_table{data, {}}
+  constexpr explicit code_table(const R& data) : code_table{data, {}}
   {}
 
   template <std::ranges::input_range R>
     requires std::convertible_to<std::ranges::range_reference_t<R>, symbol_type>
-  explicit code_table(const R& data, symbol_type eot)
+  constexpr explicit code_table(const R& data, symbol_type eot)
       : table_{detail::data_tag{}, data, eot}
   {
     construct_table();


### PR DESCRIPTION
Allow the capacity of a `code_table` with static extent to exceed the
size of the alphabet. This allows a `code_table` to be constructed from
a sequence of symbols at compile-time, provided the size of the alphabet
does not exceed the table capacity.

Change-Id: I629a87c8393fd7b2524d4ebe0afc8b7aa2ab2356