### PR TITLE
Register Clang 16.0 as the default toolchain

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,6 +1,9 @@
 build --incompatible_enable_cc_toolchain_resolution
 build --action_env="BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1"
 
+build:clang16 --extra_toolchains=//toolchain:clang16
+build:gcc12   --extra_toolchains=//toolchain:gcc12
+
 build:clang-format --aspects @bazel_clang_format//:defs.bzl%clang_format_aspect
 build:clang-format --@bazel_clang_format//:binary=@llvm_16_0_toolchain//:clang-format
 build:clang-format --@bazel_clang_format//:config=//:format_config

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -8,6 +8,19 @@ on:
 
 jobs:
   test:
+    strategy:
+      fail-fast: false
+      matrix:
+        toolchain: [gcc12, clang16]
+        feature: ['']
+        include:
+          - toolchain: clang16
+            feature: asan
+          - toolchain: clang16
+            feature: tsan
+          - toolchain: clang16
+            feature: ubsan
+
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
@@ -16,12 +29,18 @@ jobs:
       uses: actions/cache@v3
       with:
         path: "~/.cache/bazel"
-        key: bazel-test
+        key: bazel-test-${{ matrix.toolchain }}-${{ matrix.feature }}
+
+    - name: install libtinfo5
+      # clang tools link against this
+      run: sudo apt-get install -y libtinfo5
 
     - run: |
         bazel \
           --bazelrc=.github/workflows/ci.bazelrc \
           test \
+          --config=${{ matrix.toolchain }} \
+          --features=${{ matrix.feature }} \
           //...
 
   clang-format:

--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -11,6 +11,30 @@ http_archive(
 
 load("@bazel_bootlin//:defs.bzl", "bootlin_toolchain")
 
+COMMON_CXX_FLAGS = [
+    "-march=native",
+    "-fdiagnostics-color=always",
+]
+
+COMMON_CXX_WARNINGS = [
+    "-Werror",
+    "-Wall",
+    "-Wextra",
+    "-Wpedantic",
+    "-Wconversion",
+    "-Wshadow",
+    "-Wnon-virtual-dtor",
+    "-Wold-style-cast",
+    "-Wcast-align",
+    "-Wunused",
+    "-Woverloaded-virtual",
+    "-Wmisleading-indentation",
+    "-Wnull-dereference",
+    "-Wdouble-promotion",
+    "-Wformat=2",
+    "-Wimplicit-fallthrough",
+]
+
 # for mapping from buildroot version to gcc version
 # see https://toolchains.bootlin.com/releases_x86-64.html
 #
@@ -20,50 +44,11 @@ bootlin_toolchain(
     buildroot_version = "2022.08-1_bleeding",
     extra_cxxflags = [
         "-std=c++23",
-        "-march=native",
-        "-fdiagnostics-color=always",
-        "-Werror",
-        "-Wall",
-        "-Wextra",
-        "-Wpedantic",
-        "-Wconversion",
-        "-Wshadow",
-        "-Wnon-virtual-dtor",
-        "-Wold-style-cast",
-        "-Wcast-align",
-        "-Wunused",
-        "-Woverloaded-virtual",
-        "-Wmisleading-indentation",
-        "-Wnull-dereference",
-        "-Wdouble-promotion",
-        "-Wformat=2",
-        "-Wimplicit-fallthrough",
         "-Wduplicated-cond",
         "-Wduplicated-branches",
         "-Wlogical-op",
         "-Wuseless-cast",
-    ],
-)
-
-register_toolchains("@gcc_12_2_toolchain//:toolchain")
-
-BOOST_UT_VERSION = "e53a47d37bc594e80bd5f1b8dc1ade8dce4429d3"
-
-http_archive(
-    name = "boost_ut",
-    build_file_content = """
-load("@rules_cc//cc:defs.bzl", "cc_library")
-
-cc_library(
-    name = "boost_ut",
-    hdrs = ["include/boost/ut.hpp"],
-    includes = ["include"],
-    visibility = ["//visibility:public"],
-)
-""",
-    sha256 = "abc90fa389a47504d06a88a56ddc9e580cf2654173bd14d211db714bb111b923",
-    strip_prefix = "ut-%s" % BOOST_UT_VERSION,
-    url = "https://github.com/boost-ext/ut/archive/%s.tar.gz" % BOOST_UT_VERSION,
+    ] + COMMON_CXX_FLAGS + COMMON_CXX_WARNINGS,
 )
 
 BAZEL_TOOLCHAIN_VERSION = "41ff2a05c0beff439bad7acfd564e6827e34b13b"
@@ -82,7 +67,48 @@ bazel_toolchain_dependencies()
 
 llvm_toolchain(
     name = "llvm_16_0_toolchain",
+    cxx_flags = {
+        "": [
+            "-stdlib=libc++",
+            "-std=c++2b",
+        ] + COMMON_CXX_FLAGS + COMMON_CXX_WARNINGS,
+    },
+    # Link UBSan C++ runtime libraries if the `ubsan` feature is enabled
+    # https://github.com/bazelbuild/bazel/issues/12797#issuecomment-980641064
+    # use `link_libs` to prevent overriding default `link_flags`
+    # https://github.com/grailbio/bazel-toolchain/blob/ceeedcc4464322e05fe5b8df3749cc02273ee083/toolchain/cc_toolchain_config.bzl#L148-L150
+    link_libs = {
+        "": ["--driver-mode=g++"],
+    },
     llvm_version = "16.0.0",
+)
+
+# register llvm first, it has better error messages
+load("@llvm_16_0_toolchain//:toolchains.bzl", "llvm_register_toolchains")
+
+llvm_register_toolchains()
+
+register_toolchains(
+    "@gcc_12_2_toolchain//:toolchain",
+)
+
+BOOST_UT_VERSION = "e53a47d37bc594e80bd5f1b8dc1ade8dce4429d3"
+
+http_archive(
+    name = "boost_ut",
+    build_file_content = """
+load("@rules_cc//cc:defs.bzl", "cc_library")
+
+cc_library(
+    name = "boost_ut",
+    hdrs = ["include/boost/ut.hpp"],
+    includes = ["include"],
+    visibility = ["//visibility:public"],
+)
+""",
+    sha256 = "abc90fa389a47504d06a88a56ddc9e580cf2654173bd14d211db714bb111b923",
+    strip_prefix = "ut-%s" % BOOST_UT_VERSION,
+    url = "https://github.com/boost-ext/ut/archive/%s.tar.gz" % BOOST_UT_VERSION,
 )
 
 BAZEL_CLANG_FORMAT_VERSION = "f4198b68887699a4d1862e44458e4969ad69fc8a"

--- a/src/huffman_test.cpp
+++ b/src/huffman_test.cpp
@@ -25,7 +25,18 @@ public:
     return os;
   }
 
-  friend auto operator<=>(Country, Country) = default;
+  friend constexpr auto operator<=>(Country lhs, Country rhs)
+  {
+    if (const auto cmp = lhs.code_[0] <=> rhs.code_[0]; cmp != 0) {
+      return cmp;
+    }
+    return lhs.code_[1] <=> rhs.code_[1];
+  }
+
+  friend constexpr auto operator==(Country lhs, Country rhs)
+  {
+    return lhs <=> rhs == 0;
+  }
 };
 
 auto main() -> int
@@ -40,17 +51,17 @@ auto main() -> int
 
     constexpr auto table =
         "Bits\tCode\tValue\tSymbol\n"
-        "5\t11111\t31\t`\4`\n"
-        "5\t11110\t30\t`x`\n"
-        "4\t1110\t14\t`q`\n"
-        "3\t110\t6\t`n`\n"
-        "2\t10\t2\t`i`\n"
-        "1\t0\t0\t`e`\n";
+        "1\t1\t1\t`e`\n"
+        "2\t01\t1\t`i`\n"
+        "3\t001\t1\t`n`\n"
+        "4\t0001\t1\t`q`\n"
+        "5\t00001\t1\t`x`\n"
+        "5\t00000\t0\t`\4`\n";
 
     auto ss = std::stringstream{};
     ss << gpu_deflate::code_table{frequencies, eot};
 
-    expect(table == ss.view());
+    expect(table == ss.str());
   };
 
   test("code tables allow user defined types as symbols") = [] {
@@ -61,10 +72,10 @@ auto main() -> int
 
     using CodePoint = decltype(table)::code_point;
 
-    expect(CodePoint{"FR", 1UZ, 0UZ} == table.begin()[0]);
-    expect(CodePoint{"IT", 2UZ, 2UZ} == table.begin()[1]);
-    expect(CodePoint{"UK", 3UZ, 6UZ} == table.begin()[2]);
-    expect(CodePoint{"DE", 4UZ, 14UZ} == table.begin()[3]);
-    expect(CodePoint{"BE", 5UZ, 30UZ} == table.begin()[4]);
+    expect(CodePoint{"FR", 1UZ, 1UZ} == table.begin()[5]);
+    expect(CodePoint{"IT", 2UZ, 1UZ} == table.begin()[4]);
+    expect(CodePoint{"UK", 3UZ, 1UZ} == table.begin()[3]);
+    expect(CodePoint{"DE", 4UZ, 1UZ} == table.begin()[2]);
+    expect(CodePoint{"BE", 5UZ, 1UZ} == table.begin()[1]);
   };
 }

--- a/toolchain/BUILD.bazel
+++ b/toolchain/BUILD.bazel
@@ -1,7 +1,95 @@
 load("@rules_cc//cc:defs.bzl", "cc_binary")
 
+package(features = [
+    "-asan",
+    "-tsan",
+    "-ubsan",
+])
+
 # Verify that the selected C++ toolchain provides std::expected
 cc_binary(
     name = "std_expected_available",
     srcs = ["std_expected_available.cpp"],
+)
+
+alias(
+    name = "gcc12",
+    actual = "@gcc_12_2_toolchain//:toolchain",
+)
+
+alias(
+    name = "clang16",
+    actual = select({
+        "@platforms//os:macos": "@llvm_16_0_toolchain//:cc-toolchain-aarch64-darwin",
+        "//conditions:default": "@llvm_16_0_toolchain//:cc-toolchain-x86_64-linux",
+    }),
+)
+
+# Doesn't work on MacOS: https://github.com/grailbio/bazel-toolchain/issues/192
+config_setting(
+    name = "llvm_linux",
+    constraint_values = ["@platforms//os:linux"],
+    flag_values = {"@bazel_tools//tools/cpp:compiler": "clang"},
+)
+
+llvm_linux_only = select({
+    "llvm_linux": [],
+    "//conditions:default": ["@platforms//:incompatible"],
+})
+
+cc_binary(
+    name = "asan_feature",
+    srcs = ["asan_feature_available.cpp"],
+    copts = ["-O0"],
+    features = ["asan"],
+    target_compatible_with = llvm_linux_only,
+)
+
+sh_test(
+    name = "asan_feature_available",
+    srcs = ["runtime_failure.sh"],
+    args = [
+        "$(location :asan_feature)",
+        "ERROR: AddressSanitizer: stack-use-after-scope",
+    ],
+    data = [":asan_feature"],
+)
+
+cc_binary(
+    name = "tsan_feature",
+    srcs = ["tsan_feature_available.cpp"],
+    copts = ["-O0"],
+    features = ["tsan"],
+    target_compatible_with = llvm_linux_only,
+)
+
+sh_test(
+    name = "tsan_feature_available",
+    srcs = ["runtime_failure.sh"],
+    args = [
+        "$(location :tsan_feature)",
+        "WARNING: ThreadSanitizer: data race",
+    ],
+    data = [":tsan_feature"],
+)
+
+cc_binary(
+    name = "ubsan_feature",
+    srcs = ["ubsan_feature_available.cpp"],
+    copts = [
+        "-O0",
+        "-Wno-array-bounds",
+    ],
+    features = ["ubsan"],
+    target_compatible_with = llvm_linux_only,
+)
+
+sh_test(
+    name = "ubsan_feature_available",
+    srcs = ["runtime_failure.sh"],
+    args = [
+        "$(location :ubsan_feature)",
+        "runtime error: index 10 out of bounds",
+    ],
+    data = [":ubsan_feature"],
 )

--- a/toolchain/asan_feature_available.cpp
+++ b/toolchain/asan_feature_available.cpp
@@ -1,0 +1,16 @@
+// https://github.com/bazelbuild/bazel/blob/abae5ca3e8142f93cf0c2597e3410ed955c4dd59/src/test/shell/bazel/cc_integration_test.sh#L1888-L1897
+
+// clang-format off
+
+int main() {
+  volatile int* p;
+
+  {
+    volatile int x = 0;
+    p = &x;
+  }
+
+  return *p;
+}
+
+// clang-format on

--- a/toolchain/runtime_failure.sh
+++ b/toolchain/runtime_failure.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+bin=$1
+err=$2
+
+ret=0
+$bin &> log || ret=$?
+[ $ret -ne 0 ]
+
+grep -q $err log

--- a/toolchain/tsan_feature_available.cpp
+++ b/toolchain/tsan_feature_available.cpp
@@ -1,0 +1,22 @@
+// https://github.com/bazelbuild/bazel/blob/abae5ca3e8142f93cf0c2597e3410ed955c4dd59/src/test/shell/bazel/cc_integration_test.sh#L1918-L1933
+
+// clang-format off
+
+#include <thread>
+
+int value = 0;
+
+void increment() {
+  ++value;
+}
+
+int main() {
+  std::thread t1(increment);
+  std::thread t2(increment);
+  t1.join();
+  t2.join();
+
+  return value;
+}
+
+// clang-format on

--- a/toolchain/ubsan_feature_available.cpp
+++ b/toolchain/ubsan_feature_available.cpp
@@ -1,0 +1,10 @@
+// https://github.com/bazelbuild/bazel/blob/abae5ca3e8142f93cf0c2597e3410ed955c4dd59/src/test/shell/bazel/cc_integration_test.sh#LL1954C1-L1957C2
+
+// clang-format off
+
+int main() {
+  int array[10];
+  return array[10];
+}
+
+// clang-format on


### PR DESCRIPTION
Add Clang 16.0 as the default C++ toolchain. Both GCC 12.2 and Clang
16.0 are tested in the Github check workflow. The test workflow also
verifies that sanitizer features `asan`, `tsan`, and `ubsan` are
available with Clang.

The creation of the huffman tree contained an expression without a well
defined order of evaluation, resulting in different behavior between GCC
and Clang. This is updated to use a well defined order and reflected in
the tests.

Also support building on MacOS, though not with sanitizers.

Change-Id: I2c02446a5e419fdc2e7b6af23a43c002f2343f08