### PR TITLE
Add clang-tidy configuration

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -8,6 +8,14 @@ build:clang-format --aspects @bazel_clang_format//:defs.bzl%clang_format_aspect
 build:clang-format --@bazel_clang_format//:binary=@llvm_16_0_toolchain//:clang-format
 build:clang-format --@bazel_clang_format//:config=//:format_config
 build:clang-format --output_groups=report
+build:clang-format --keep_going
+
+build:clang-tidy --config=clang16
+build:clang-tidy --aspects @bazel_clang_tidy//clang_tidy:clang_tidy.bzl%clang_tidy_aspect
+build:clang-tidy --@bazel_clang_tidy//:clang_tidy_executable=@llvm_16_0_toolchain//:clang-tidy
+build:clang-tidy --output_groups=report
+build:clang-tidy --spawn_strategy=local
+build:clang-tidy --keep_going
 
 try-import %workspace%/user.bazelrc
 

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,51 @@
+UseColor: true
+
+Checks: >
+    bugprone-*,
+    clang-analyzer-cplusplus*,
+    concurrency-*,
+    cppcoreguidelines-*,
+    misc-*,
+    modernize-*,
+    performance-*,
+    readability-*,
+
+    # Bazel does this for determinism,
+    -clang-diagnostic-builtin-macro-redefined,
+
+    # suppress due to assert,
+    -cppcoreguidelines-pro-bounds-array-to-pointer-decay,
+
+    # short names are fine for short lifetimes,
+    -readability-identifier-length,
+
+    # allow unused variables to be unnamed,
+    -readability-named-parameter,
+
+    # C-arrays necessary as function args,
+    -modernize-avoid-c-arrays,
+
+    # false positive with spaceship operator,
+    # https://reviews.llvm.org/D95714?id=320393,
+    -modernize-use-nullptr,
+
+    # disable common aliases,
+    -cppcoreguidelines-avoid-c-arrays,
+    -cppcoreguidelines-avoid-magic-numbers,
+    -cppcoreguidelines-c-copy-assignment-signature,
+    -cppcoreguidelines-explicit-virtual-functions,
+    -cppcoreguidelines-non-private-member-variables-in-classes,
+
+CheckOptions:
+    - key: misc-non-private-member-variables-in-classes.IgnoreClassesWithAllMemberVariablesBeingPublic
+      value: 1
+
+HeaderFilterRegex: '.*'
+
+# clang-diagnostic-builtin-macro-redefined must be manually suppressed here
+# https://github.com/erenon/bazel_clang_tidy/issues/29
+# https://github.com/llvm/llvm-project/issues/56709
+#
+WarningsAsErrors: '*,-clang-diagnostic-builtin-macro-redefined'
+
+

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -43,7 +43,12 @@ jobs:
           --features=${{ matrix.feature }} \
           //...
 
-  clang-format:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        config: [clang-format, clang-tidy]
+
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
@@ -52,17 +57,17 @@ jobs:
       uses: actions/cache@v3
       with:
         path: "~/.cache/bazel"
-        key: bazel-clang-format
+        key: bazel-build-${{ matrix.config }}
 
     - name: install libtinfo5
-      # clang format links against this
+      # clang tools link against this
       run: sudo apt-get install -y libtinfo5
 
     - run: |
         bazel \
           --bazelrc=.github/workflows/ci.bazelrc \
           build \
-          --config=clang-format \
+          --config=${{ matrix.config }} \
           //...
 
   buildifier:

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@bazel_clang_format//:defs.bzl", "clang_format_update")
+load("@bazel_clang_tidy//:defs.bzl", "clang_tidy_apply_fixes")
 load("@buildifier_prebuilt//:rules.bzl", "buildifier")
 
 package(default_visibility = ["//visibility:public"])
@@ -9,10 +10,26 @@ filegroup(
     visibility = ["//visibility:public"],
 )
 
+filegroup(
+    name = "tidy_config",
+    srcs = [".clang-tidy"],
+    visibility = ["//visibility:public"],
+)
+
 clang_format_update(
     name = "clang-format",
     binary = "@llvm_16_0_toolchain//:clang-format",
     config = ":format_config",
+)
+
+clang_tidy_apply_fixes(
+    name = "clang-tidy-fix",
+    apply_replacements_binary = "@llvm_16_0_toolchain//:clang-apply-replacements",
+    extra_config_args = [
+        "--spawn_strategy=local",
+    ],
+    tidy_binary = "@llvm_16_0_toolchain//:clang-tidy",
+    tidy_config = ":tidy_config",
 )
 
 buildifier(

--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -120,6 +120,15 @@ http_archive(
     url = "https://github.com/oliverlee/bazel_clang_format/archive/%s.tar.gz" % BAZEL_CLANG_FORMAT_VERSION,
 )
 
+BAZEL_CLANG_TIDY_VERSION = "79921ab3346d61c7ae963f8fcbb7a9dc988a51bd"
+
+http_archive(
+    name = "bazel_clang_tidy",
+    sha256 = "79a6321fac9d0bba5521964971be6f2b352fd6018a3ff5ca3f43521b10c9c344",
+    strip_prefix = "bazel_clang_tidy-%s" % BAZEL_CLANG_TIDY_VERSION,
+    url = "https://github.com/oliverlee/bazel_clang_tidy/archive/%s.tar.gz" % BAZEL_CLANG_TIDY_VERSION,
+)
+
 http_archive(
     name = "buildifier_prebuilt",
     sha256 = "e46c16180bc49487bfd0f1ffa7345364718c57334fa0b5b67cb5f27eba10f309",

--- a/src/.clang-tidy
+++ b/src/.clang-tidy
@@ -1,0 +1,1 @@
+../.clang-tidy

--- a/src/BUILD.bazel
+++ b/src/BUILD.bazel
@@ -1,24 +1,13 @@
+load("@rules_cc//cc:defs.bzl", "cc_library")
+
+package(default_visibility = ["//src:__subpackages__"])
+
 cc_library(
     name = "decompress",
     hdrs = ["decompress.hpp"],
 )
 
-cc_test(
-    name = "decompress_test",
-    srcs = ["decompress_test.cpp"],
-    deps = [":decompress"],
-)
-
 cc_library(
     name = "huffman",
     hdrs = ["huffman.hpp"],
-)
-
-cc_test(
-    name = "huffman_test",
-    srcs = ["huffman_test.cpp"],
-    deps = [
-        ":huffman",
-        "@boost_ut",
-    ],
 )

--- a/src/decompress.hpp
+++ b/src/decompress.hpp
@@ -16,8 +16,9 @@ enum class Error : std::uint8_t
 
 // Inspired by https://docs.python.org/3/library/zlib.html#zlib.decompress
 template <std::size_t N, class ByteAllocator = std::allocator<std::byte>>
-std::expected<std::vector<std::byte>, Error>
-decompress(std::span<const std::byte, N> compressed, ByteAllocator alloc = {})
+auto decompress(
+    std::span<const std::byte, N> compressed, ByteAllocator alloc = {})
+    -> std::expected<std::vector<std::byte>, Error>
 {
   (void)compressed;
   auto decompressed = std::vector<std::byte, ByteAllocator>(alloc);

--- a/src/decompress_test.cpp
+++ b/src/decompress_test.cpp
@@ -1,6 +1,0 @@
-#include "decompress.hpp"
-
-int main()
-{
-  return 0;
-}

--- a/src/huffman.hpp
+++ b/src/huffman.hpp
@@ -36,6 +36,8 @@ constexpr auto join(Consume auto&& container, Consume auto&& range)
       std::make_move_iterator(std::begin(range)),
       std::make_move_iterator(std::end(range)));
 
+  // false positive, `container` is an rvalue
+  // NOLINTNEXTLINE(bugprone-move-forwarding-reference)
   return std::move(container);
 }
 }  // namespace detail
@@ -91,7 +93,11 @@ public:
       }
     };
 
-    constexpr auto code() const -> code_type { return {bitsize, value}; }
+    [[nodiscard]]
+    constexpr auto code() const -> code_type
+    {
+      return {bitsize, value};
+    }
 
     friend auto
     operator<<(std::ostream& os, const code_point& point) -> std::ostream&
@@ -204,9 +210,17 @@ public:
   ///
   /// @{
 
-  auto begin() const { return table_.begin(); }
+  [[nodiscard]]
+  auto begin() const
+  {
+    return table_.begin();
+  }
 
-  auto end() const { return table_.end(); }
+  [[nodiscard]]
+  auto end() const
+  {
+    return table_.end();
+  }
 
   /// @}
 

--- a/src/test/.clang-tidy
+++ b/src/test/.clang-tidy
@@ -1,0 +1,12 @@
+# This does not appear to allow chained inheritance
+InheritParentConfig: true
+
+Checks: >
+    # allow magic numbers in tests,
+    -readability-magic-numbers,
+
+    # allow namespace using directives in tests,
+    -google-build-using-namespace,
+
+    # don't catch all exceptions,
+    -bugprone-exception-escape,

--- a/src/test/BUILD.bazel
+++ b/src/test/BUILD.bazel
@@ -1,0 +1,18 @@
+load("@rules_cc//cc:defs.bzl", "cc_test")
+
+cc_test(
+    name = "decompress",
+    srcs = ["decompress.cpp"],
+    deps = [
+        "//src:decompress",
+    ],
+)
+
+cc_test(
+    name = "huffman",
+    srcs = ["huffman.cpp"],
+    deps = [
+        "//src:huffman",
+        "@boost_ut",
+    ],
+)

--- a/src/test/decompress.cpp
+++ b/src/test/decompress.cpp
@@ -1,0 +1,6 @@
+#include "src/decompress.hpp"
+
+auto main() -> int
+{
+  return 0;
+}

--- a/src/test/huffman.cpp
+++ b/src/test/huffman.cpp
@@ -1,4 +1,4 @@
-#include "huffman.hpp"
+#include "src/huffman.hpp"
 
 #include <boost/ut.hpp>
 
@@ -15,6 +15,9 @@ class Country
 
 public:
   Country() = default;
+
+  // allow implicit conversions to simplify construction of test data
+  // NOLINTNEXTLINE(google-explicit-constructor)
   Country(const char (&code)[3]) : code_{code[0], code[1]} {}
 
   friend auto operator<<(std::ostream& os, Country c) -> std::ostream&

--- a/toolchain/.clang-tidy
+++ b/toolchain/.clang-tidy
@@ -1,0 +1,9 @@
+Checks: >
+    -*,
+
+    # dummy, see below,
+    misc-definitions-in-headers,
+
+CheckOptions:
+  - key: HeaderFileExtensions
+    value: "x"


### PR DESCRIPTION
Pull in @bazel_clang_tidy to enable clang-tidy with a hermetic
toolchain. This job also adds a clang-tidy job to the check workflow.

To run clang-tidy on source files:

 bazel build //... --config=clang-tidy

For clang-tidy checks that have fixes, those can be applied with

 bazel run //:clang-tidy-fix

This commit also applies fixes and check suppressions to source files.

In order to allow different rulesets for test code, tests have been
moved into a separate test directory.

Change-Id: If22bbd78ae36068d9425898723db5480127e2ea2