### PR TITLE
Reduce allocations on `code_table` construction

### DIFF
--- a/src/test/huffman.cpp
+++ b/src/test/huffman.cpp
@@ -54,12 +54,12 @@ auto main() -> int
 
     constexpr auto table =
         "Bits\tCode\tValue\tSymbol\n"
-        "1\t1\t1\t`e`\n"
-        "2\t01\t1\t`i`\n"
-        "3\t001\t1\t`n`\n"
-        "4\t0001\t1\t`q`\n"
-        "5\t00001\t1\t`x`\n"
-        "5\t00000\t0\t`\4`\n";
+        "5\t11111\t0\t`\4`\n"
+        "5\t11110\t1\t`x`\n"
+        "4\t1110\t1\t`q`\n"
+        "3\t110\t1\t`n`\n"
+        "2\t10\t1\t`i`\n"
+        "1\t0\t1\t`e`\n";
 
     auto ss = std::stringstream{};
     ss << gpu_deflate::code_table{frequencies, eot};


### PR DESCRIPTION
Remove use of `std::priority_queue` on construction of a `code_table`.
Construction no longer creates a `std::vector` for each symbol. Instead,
the Huffman tree is created in-place.

In addition, this commit also:
* adds the `[[nodiscard]]` attribute to functions without side effects
* simplifies the `code_table` CTAD constraints
* requires a `Symbol` to be totally ordered

Change-Id: Ica17732f060dd101084feca36229c6496bc95cb1