### PR TITLE
Separate out storage type for `code_table`

### DIFF
--- a/src/BUILD.bazel
+++ b/src/BUILD.bazel
@@ -9,5 +9,8 @@ cc_library(
 
 cc_library(
     name = "huffman",
+    srcs = [
+        "detail/huffman_storage.hpp",
+    ],
     hdrs = ["huffman.hpp"],
 )

--- a/src/detail/huffman_storage.hpp
+++ b/src/detail/huffman_storage.hpp
@@ -1,0 +1,43 @@
+#pragma once
+
+#include <cassert>
+#include <cstddef>
+#include <span>
+#include <vector>
+
+namespace gpu_deflate::detail {
+
+template <class intrusive_node, std::size_t Extent>
+class huffman_storage : std::vector<intrusive_node>
+{
+  static_assert(Extent == std::dynamic_extent, "not yet implemented");
+
+public:
+  using base_type = std::vector<intrusive_node>;
+
+  template <class R>
+  huffman_storage(
+      const R& frequencies, typename intrusive_node::symbol_type eot)
+      : base_type{}
+  {
+    base_type::reserve(frequencies.size() + 1UZ);  // +1 for EOT
+    base_type::emplace_back(eot, 1UZ);
+
+    for (auto [symbol, freq] : frequencies) {
+      assert(symbol != eot);
+      assert(freq);
+
+      base_type::emplace_back(symbol, freq);
+    }
+  }
+
+  using base_type::begin;
+  using base_type::cbegin;
+  using base_type::cend;
+  using base_type::data;
+  using base_type::end;
+  using base_type::front;
+  using base_type::size;
+};
+
+}  // namespace gpu_deflate::detail

--- a/src/huffman.hpp
+++ b/src/huffman.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "detail/huffman_storage.hpp"
+
 #include <algorithm>
 #include <cassert>
 #include <compare>
@@ -11,8 +13,8 @@
 #include <iterator>
 #include <numeric>
 #include <ranges>
+#include <span>
 #include <tuple>
-#include <vector>
 
 namespace gpu_deflate {
 
@@ -38,10 +40,11 @@ struct code_type
 
 /// Huffman code table
 /// @tparam Symbol symbol type
+/// @tparam Extent upper bound for alphabet size
 ///
-/// Determines the Huffman code for a collection of symbols
+/// Determines the Huffman code for a collection of symbols.
 ///
-template <std::regular Symbol>
+template <std::regular Symbol, std::size_t Extent = std::dynamic_extent>
   requires std::totally_ordered<Symbol>
 class code_table
 {
@@ -54,6 +57,8 @@ public:
   ///
   struct code_point
   {
+    using symbol_type = Symbol;
+
     symbol_type symbol{};
     std::uint8_t bitsize{};
     std::size_t value{};
@@ -126,6 +131,8 @@ private:
     std::size_t node_size_{1UZ};
 
   public:
+    using symbol_type = typename code_point::symbol_type;
+
     /// Construct a leaf node for a symbol and its frequency
     ///
     constexpr intrusive_node(symbol_type sym, std::size_t freq)
@@ -220,7 +227,7 @@ private:
     }
   };
 
-  std::vector<intrusive_node> table_{};
+  detail::huffman_storage<intrusive_node, Extent> table_;
 
   auto base_range() const
   {
@@ -261,23 +268,13 @@ public:
     requires std::convertible_to<
         std::ranges::range_value_t<R>,
         std::tuple<symbol_type, std::size_t>>
-  code_table(const R& frequencies, symbol_type eot)
+  code_table(const R& frequencies, symbol_type eot) : table_{frequencies, eot}
   {
     const auto total_freq = std::accumulate(
         std::cbegin(frequencies),
         std::cend(frequencies),
         1UZ,  // for EOT which we add later.
         [](auto acc, auto kv) { return acc + kv.second; });
-
-    table_.reserve(frequencies.size() + 1UZ);  // +1 for EOT
-    table_.emplace_back(eot, 1UZ);
-
-    for (auto [symbol, freq] : frequencies) {
-      assert(symbol != eot);
-      assert(freq);
-
-      table_.emplace_back(symbol, freq);
-    }
 
     std::ranges::sort(table_);
 


### PR DESCRIPTION
Instead of using `std::vector` directly as the underlying storage type
of `code_tree`, define `detail::huffman_storage` type. In this commit,
`detail::huffman_storage` inherits from `std::vector` and does not
change any behavior of `code_table`. However, this will simplify a
following commit that allows use of `std::array` as the storage type.

Change-Id: I27c29eda68f139aff8c3fbaa3f54c4a57ca1ab19