### PR TITLE
Define `code::bit_view()` and literal `_c`

### DIFF
--- a/huffman/src/code.hpp
+++ b/huffman/src/code.hpp
@@ -1,9 +1,12 @@
 #pragma once
 
+#include <cassert>
 #include <concepts>
 #include <cstddef>
 #include <cstdint>
 #include <ostream>
+#include <ranges>
+#include <utility>
 
 namespace gpu_deflate::huffman {
 
@@ -14,13 +17,19 @@ struct code
   std::uint8_t bitsize{};
   std::size_t value{};
 
+  [[nodiscard]]
+  constexpr auto bit_view() const
+  {
+    return std::views::iota(0UZ, std::size_t{bitsize}) | std::views::reverse |
+           std::views::transform([value = this->value](auto n) {
+             return (value & 1UZ << n) ? '1' : '0';
+           });
+  }
+
   friend auto operator<<(std::ostream& os, const code& c) -> std::ostream&
   {
-    auto bits = c.bitsize;
-
-    while (bits != 0UZ) {
-      --bits;
-      os << (((1UZ << bits) & c.value) != 0UZ ? '0' : '1');
+    for (auto bit : c.bit_view()) {
+      os << bit;
     }
 
     return os;
@@ -31,4 +40,29 @@ struct code
   operator<=>(const code&, const code&) = default;
 };
 
+namespace detail {
+
+inline constexpr auto bit_shift = [](char c, std::size_t n) {
+  assert(c == '0' or c == '1');
+
+  return ((c - '0') == 0 ? 0UZ : 1UZ) << n;
+};
+
+}
+
+namespace literals {
+
+template <char... Bits>
+consteval auto operator""_c() -> code
+{
+  constexpr auto N = sizeof...(Bits);
+
+  using ::gpu_deflate::huffman::detail::bit_shift;
+
+  return {N, []<std::size_t... Is>(std::index_sequence<Is...>) {
+            return (bit_shift(Bits, N - 1 - Is) | ...);
+          }(std::make_index_sequence<N>{})};
+}
+
+}  // namespace literals
 }  // namespace gpu_deflate::huffman

--- a/huffman/test/BUILD.bazel
+++ b/huffman/test/BUILD.bazel
@@ -1,6 +1,15 @@
 load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_test")
 
 cc_test(
+    name = "code_test",
+    srcs = ["code_test.cpp"],
+    deps = [
+        "//huffman",
+        "@boost_ut",
+    ],
+)
+
+cc_test(
     name = "table_from_frequencies_test",
     srcs = ["table_from_frequencies_test.cpp"],
     deps = [

--- a/huffman/test/code_test.cpp
+++ b/huffman/test/code_test.cpp
@@ -1,0 +1,66 @@
+#include "huffman/huffman.hpp"
+
+#include <boost/ut.hpp>
+
+#include <algorithm>
+#include <string_view>
+
+auto main() -> int
+{
+  using namespace std::literals::string_view_literals;
+  using ::boost::ut::expect;
+  using ::boost::ut::test;
+
+  namespace huffman = ::gpu_deflate::huffman;
+
+  static const auto to_string = [](huffman::code code) {
+    auto ss = std::stringstream{};
+    ss << code;
+    return ss.str();
+  };
+
+  // NOLINTBEGIN(readability-magic-numbers)
+
+  test("code is streamable") = [] {
+    expect(std::ranges::equal(
+        "0"sv, to_string(huffman::code{.bitsize = 1, .value = 0})));
+    expect(std::ranges::equal(
+        "10"sv, to_string(huffman::code{.bitsize = 2, .value = 0b10})));
+    expect(std::ranges::equal(
+        "110"sv, to_string(huffman::code{.bitsize = 3, .value = 0b110})));
+    expect(std::ranges::equal(
+        "1110"sv, to_string(huffman::code{.bitsize = 4, .value = 0b1110})));
+    expect(std::ranges::equal(
+        "11110"sv, to_string(huffman::code{.bitsize = 5, .value = 0b11110})));
+    expect(std::ranges::equal(
+        "11111"sv, to_string(huffman::code{.bitsize = 5, .value = 0b11111})));
+  };
+
+  static const auto has_bits = [](std::string_view sv, huffman::code code) {
+    return std::ranges::equal(sv, code.bit_view());
+  };
+
+  test("code is convertible to range") = [] {
+    static_assert(has_bits("0"sv, huffman::code{.bitsize = 1, .value = 0}));
+    static_assert(
+        has_bits("11110"sv, huffman::code{.bitsize = 5, .value = 0b11110}));
+  };
+
+  test("code is constructible with literal") = [] {
+    using namespace huffman::literals;
+
+    expect(has_bits("1"sv, 1_c));
+    expect(has_bits("0"sv, 0_c));
+
+    expect(has_bits("11"sv, 11_c));
+    expect(has_bits("10"sv, 10_c));
+    expect(has_bits("01"sv, 01_c));
+    expect(has_bits("00"sv, 00_c));
+
+    expect(has_bits("11111"sv, 11111_c));
+    expect(has_bits("11110"sv, 11110_c));
+    expect(has_bits("00000"sv, 00000_c));
+  };
+
+  // NOLINTEND(readability-magic-numbers)
+}

--- a/huffman/test/table_from_frequencies_test.cpp
+++ b/huffman/test/table_from_frequencies_test.cpp
@@ -61,17 +61,17 @@ auto main() -> int
 
     constexpr auto table =
         "Bits\tCode\tValue\tSymbol\n"
-        "1\t0\t1\t`e`\n"
-        "2\t10\t1\t`i`\n"
-        "3\t110\t1\t`n`\n"
-        "4\t1110\t1\t`q`\n"
-        "5\t11110\t1\t`x`\n"
-        "5\t11111\t0\t`\4`\n";
+        "1\t1\t1\t`e`\n"
+        "2\t01\t1\t`i`\n"
+        "3\t001\t1\t`n`\n"
+        "4\t0001\t1\t`q`\n"
+        "5\t00001\t1\t`x`\n"
+        "5\t00000\t0\t`\4`\n";
 
     auto ss = std::stringstream{};
     ss << huffman::table{frequencies, eot};
 
-    expect(table == ss.str());
+    expect(table == ss.str()) << ss.str();
   };
 
   test("code tables allow user defined types as symbols") = [] {


### PR DESCRIPTION
`code::bit_view()` returns a view of the bits in a code as chars with
value `0` or `1`.

`operator::_c` provides simpler shorthand for creating a code
literal, which is particularly useful in tests:

 assert(code{.bitsize = 3, .value = 0b010} == 010_c)

Change-Id: I1f4b938e76c29ce0a0414daddb0555251017606a