### PR TITLE
Disable very slow clang-tidy checks

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -10,12 +10,17 @@ build:clang-format --@bazel_clang_format//:config=//:format_config
 build:clang-format --output_groups=report
 build:clang-format --keep_going
 
-build:clang-tidy --config=clang16
-build:clang-tidy --aspects @bazel_clang_tidy//clang_tidy:clang_tidy.bzl%clang_tidy_aspect
+build:clang-tidy-base --config=clang16
+build:clang-tidy-base --aspects @bazel_clang_tidy//clang_tidy:clang_tidy.bzl%clang_tidy_aspect
+build:clang-tidy-base --@bazel_clang_tidy//:clang_tidy_config=//:tidy_config
+build:clang-tidy-base --output_groups=report
+build:clang-tidy-base --keep_going
+
+build:verbose-clang-tidy --config=clang-tidy-base
+build:verbose-clang-tidy --@bazel_clang_tidy//:clang_tidy_executable=//tools:verbose-clang-tidy
+
+build:clang-tidy --config=clang-tidy-base
 build:clang-tidy --@bazel_clang_tidy//:clang_tidy_executable=@llvm_16_0_toolchain//:clang-tidy
-build:clang-tidy --@bazel_clang_tidy//:clang_tidy_config=//:tidy_config
-build:clang-tidy --output_groups=report
-build:clang-tidy --keep_going
 
 try-import %workspace%/user.bazelrc
 

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -42,12 +42,17 @@ Checks: >
     -cppcoreguidelines-explicit-virtual-functions,
     -cppcoreguidelines-non-private-member-variables-in-classes,
 
+    # disable EXTREMELY SLOW checks,
+    -bugprone-reserved-identifier,
+    -readability-identifier-naming,
+    -misc-confusable-identifiers,
+
 CheckOptions:
     - key: misc-non-private-member-variables-in-classes.IgnoreClassesWithAllMemberVariablesBeingPublic
       value: 1
 
-# only lint files under `src`
-HeaderFilterRegex: '__main__/src'
+# only lint files coming from this project
+HeaderFilterRegex: '__main__/'
 
 # clang-diagnostic-builtin-macro-redefined must be manually suppressed here
 # https://github.com/erenon/bazel_clang_tidy/issues/29

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -40,7 +40,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        flag: [--config=clang-format, --config=clang-tidy, --compilation_mode=opt]
+        flag:
+          - '--config=clang-format'
+          - '--config=clang-tidy'
+          - '--config=verbose-clang-tidy'
+          - '--compilation_mode=opt'
 
     runs-on: ubuntu-latest
     steps:

--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -133,11 +133,11 @@ http_archive(
     url = "https://github.com/oliverlee/bazel_clang_format/archive/%s.tar.gz" % BAZEL_CLANG_FORMAT_VERSION,
 )
 
-BAZEL_CLANG_TIDY_VERSION = "79921ab3346d61c7ae963f8fcbb7a9dc988a51bd"
+BAZEL_CLANG_TIDY_VERSION = "ba5e6709229ac56f166326fedce99820da81ca4b"
 
 http_archive(
     name = "bazel_clang_tidy",
-    sha256 = "79a6321fac9d0bba5521964971be6f2b352fd6018a3ff5ca3f43521b10c9c344",
+    sha256 = "7b71307778e69be250d548e66386776962b564cad29d748cf070adab899afe20",
     strip_prefix = "bazel_clang_tidy-%s" % BAZEL_CLANG_TIDY_VERSION,
     url = "https://github.com/oliverlee/bazel_clang_tidy/archive/%s.tar.gz" % BAZEL_CLANG_TIDY_VERSION,
 )

--- a/tools/BUILD.bazel
+++ b/tools/BUILD.bazel
@@ -1,0 +1,19 @@
+genrule(
+    name = "gen_verbose_clang_tidy",
+    srcs = [],
+    outs = ["verbose-clang-tidy.sh"],
+    # echo "$(dirname bazel-out/k8-fastbuild/bin/tools/verbose-clang-tidy.sh)/../<tidy-path>) ..."
+    cmd = """
+echo "$$(dirname $@)/../$(rootpath {tidy}) --enable-check-profile \\$$@" > $@
+""".format(
+        tidy = "@llvm_16_0_toolchain//:clang-tidy",
+    ),
+    executable = True,
+    tools = ["@llvm_16_0_toolchain//:clang-tidy"],
+)
+
+sh_binary(
+    name = "verbose-clang-tidy",
+    srcs = ["verbose-clang-tidy.sh"],
+    data = ["@llvm_16_0_toolchain//:clang-tidy"],
+)


### PR DESCRIPTION
From a run on my local machine:

INFO: From Run clang-tidy on huffman/test/table_from_data_test.cpp:
===-------------------------------------------------------------------------===
                          clang-tidy checks profiling
===-------------------------------------------------------------------------===
  Total Execution Time: 422.6479 seconds (422.6704 wall clock)

   ---User Time---   --System Time--   --User+System--   ---Wall Time---  --- Name ---
  202.0039 ( 48.1%)   0.0885 (  3.7%)  202.0923 ( 47.8%)  202.1033 ( 47.8%)  bugprone-reserved-identifier
  201.4224 ( 47.9%)   0.0697 (  2.9%)  201.4921 ( 47.7%)  201.5031 ( 47.7%)  readability-identifier-naming
   3.4124 (  0.8%)   0.4181 ( 17.6%)   3.8304 (  0.9%)   3.8280 (  0.9%)  misc-confusable-identifiers

  ...

This commit updates @bazel_clang_tidy to propagate executable runfiles,
allowing use of a wrapper script for `clang-tidy` which prepends the
flag `--enable-check-profile`. This wrapper is used with
`--config=verbose-clang-tidy`.

The check workflow also adds a build `--config=verbose-clang-tidy` to
provide profiling information.

Change-Id: I0b096f2f9c5469094640eb4bba4e950bce462a25