### PR TITLE
Separate out storage type for `code_table`

### DIFF
--- a/src/huffman.hpp
+++ b/src/huffman.hpp
@@ -44,6 +44,11 @@ struct code_type
 ///
 /// Determines the Huffman code for a collection of symbols.
 ///
+/// If `Extent` is `std::dynamic_extent`, the maximum alphabet size is
+/// undetermined and `std::vector` is used to store the Huffman tree. Otherwise,
+/// `std::array` is used to store the Huffman tree, with the size determined by
+/// `Extent`.
+///
 template <std::regular Symbol, std::size_t Extent = std::dynamic_extent>
   requires std::totally_ordered<Symbol>
 class code_table


### PR DESCRIPTION
Instead of using `std::vector` directly as the underlying storage type
of `code_tree`, define `detail::huffman_storage` type. In this commit,
`detail::huffman_storage` inherits from `std::vector` and does not
change any behavior of `code_table`. However, this will simplify a
following commit that allows use of `std::array` as the storage type.

Change-Id: I27c29eda68f139aff8c3fbaa3f54c4a57ca1ab19