### PR TITLE
Define a `bit` type

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -49,7 +49,9 @@ Checks: >
 
 CheckOptions:
     - key: misc-non-private-member-variables-in-classes.IgnoreClassesWithAllMemberVariablesBeingPublic
-      value: 1
+      value: true
+    - key: performance-move-const-arg.CheckTriviallyCopyableMove
+      value: false
 
 # only lint files coming from this project
 HeaderFilterRegex: '__main__/'

--- a/huffman/BUILD.bazel
+++ b/huffman/BUILD.bazel
@@ -3,6 +3,7 @@ load("@rules_cc//cc:defs.bzl", "cc_library")
 cc_library(
     name = "huffman",
     srcs = [
+        "src/bit.hpp",
         "src/code.hpp",
         "src/detail/static_vector.hpp",
         "src/detail/table_node.hpp",

--- a/huffman/huffman.hpp
+++ b/huffman/huffman.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "huffman/src/bit.hpp"
 #include "huffman/src/code.hpp"
 #include "huffman/src/encoding.hpp"
 #include "huffman/src/table.hpp"

--- a/huffman/src/bit.hpp
+++ b/huffman/src/bit.hpp
@@ -1,0 +1,80 @@
+#pragma once
+
+#include <cassert>
+#include <ostream>
+
+namespace gpu_deflate::huffman {
+
+/// A distinct type to represent a bit
+///
+/// A type representing a bit. It is used for strongly-typed bit operations with
+/// `code` values.
+///
+class bit
+{
+  bool value_{};
+
+public:
+  /// Constructs a zero-bit
+  ///
+  bit() = default;
+
+  /// Constructs a bit from an int
+  /// @pre value == 1 or value == 0
+  ///
+  constexpr explicit bit(int value) : value_{value == 1}
+  {
+    assert(value == 1 or value == 0);
+  }
+
+  /// Constructs a bit from a char
+  /// @pre value == '1' or value == '0'
+  ///
+  constexpr explicit bit(char value) : value_{value == '1'}
+  {
+    assert(value == '1' or value == '0');
+  }
+
+  /// Constructs a bit from a bool
+  ///
+  constexpr explicit bit(bool value) : value_{value} {}
+
+  /// Obtains the representation as a `bool`
+  ///
+  constexpr explicit operator bool() const noexcept { return value_; }
+
+  /// Obtains the representation as a `char`
+  ///
+  constexpr explicit operator char() const noexcept
+  {
+    return value_ ? '1' : '0';
+  }
+
+  /// Inserts a textual representation of `b` into `os`
+  ///
+  friend auto operator<<(std::ostream& os, bit b) -> std::ostream&
+  {
+    os << static_cast<char>(b);
+    return os;
+  }
+
+  /// Compares two bits
+  ///
+  friend auto operator==(bit, bit) -> bool = default;
+};
+
+namespace literals {
+
+/// Forms a `bit` literal
+///
+consteval auto operator""_b(unsigned long long int n) -> bit
+{
+  using I [[maybe_unused]] = unsigned long long int;
+  assert(n == I{} or n == I{1});
+
+  return bit{static_cast<int>(n)};
+}
+
+}  // namespace literals
+
+}  // namespace gpu_deflate::huffman

--- a/huffman/src/code.hpp
+++ b/huffman/src/code.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "huffman/src/bit.hpp"
+
 #include <cassert>
 #include <concepts>
 #include <cstddef>
@@ -14,18 +16,44 @@ namespace gpu_deflate::huffman {
 ///
 struct code
 {
+  /// The number of bits used to represent the code
+  ///
   std::uint8_t bitsize{};
+
+  /// The integral value of the code
+  ///
   std::size_t value{};
 
+  /// Returns a view of `*this` as a range of bits, from left to right
+  ///
   [[nodiscard]]
   constexpr auto bit_view() const
   {
     return std::views::iota(0UZ, std::size_t{bitsize}) | std::views::reverse |
            std::views::transform([value = this->value](auto n) {
-             return (value & 1UZ << n) ? '1' : '0';
+             return (value & 1UZ << n) ? bit{1} : bit{0};
            });
   }
 
+  /// Left pad `c` with `b`
+  ///
+  friend constexpr auto operator>>(bit b, code& c) -> code&
+  {
+    if (b) {
+      c.value += (1UZ << c.bitsize);
+    }
+
+    ++c.bitsize;
+    return c;
+  }
+  friend constexpr auto operator>>(bit b, code&& c) -> code&&
+  {
+    b >> c;
+    return std::move(c);
+  }
+
+  /// Inserts a textual representation of `c` into `os`
+  ///
   friend auto operator<<(std::ostream& os, const code& c) -> std::ostream&
   {
     for (auto bit : c.bit_view()) {
@@ -35,6 +63,8 @@ struct code
     return os;
   }
 
+  /// Compares two codes
+  ///
   [[nodiscard]]
   friend auto
   operator<=>(const code&, const code&) = default;
@@ -52,6 +82,8 @@ inline constexpr auto bit_shift = [](char c, std::size_t n) {
 
 namespace literals {
 
+/// Forms a `code` literal
+///
 template <char... Bits>
 consteval auto operator""_c() -> code
 {

--- a/huffman/src/detail/table_node.hpp
+++ b/huffman/src/detail/table_node.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "huffman/src/bit.hpp"
+#include "huffman/src/code.hpp"
 #include "huffman/src/encoding.hpp"
 
 #include <algorithm>
@@ -114,11 +116,12 @@ public:
   ///
   constexpr auto join_with_next() & -> void
   {
-    const auto on_base = [](auto f) {
-      return [f](table_node& n) { std::invoke(f, n.base()); };
+    const auto left_pad_with = [](auto b) {
+      return [b](table_node& n) { b >> static_cast<code&>(n); };
     };
-    std::for_each(this, next(), on_base(&encoding_type::pad_with_0));
-    std::for_each(next(), next()->next(), on_base(&encoding_type::pad_with_1));
+
+    std::for_each(this, next(), left_pad_with(bit{0}));
+    std::for_each(next(), next()->next(), left_pad_with(bit{1}));
 
     const auto& n = *next();
     frequency_ += n.frequency();

--- a/huffman/src/encoding.hpp
+++ b/huffman/src/encoding.hpp
@@ -31,32 +31,14 @@ struct encoding : code
 
   /// Construct an encoding for a symbol with a specific code
   ///
-  constexpr explicit encoding(symbol_type s, code c)
-      : ::gpu_deflate::huffman::code{c}, symbol{s}
-  {}
-
-  /// Left pad the code of `*this` with a 0
-  ///
-  constexpr auto pad_with_0() -> void { ++bitsize; }
-
-  /// Left pad the code of `*this` with a 1
-  ///
-  constexpr auto pad_with_1() -> void { value += (1UZ << bitsize++); }
-
-  /// Returns the encoding for `*this`
-  ///
-  [[nodiscard]]
-  constexpr auto code() const -> ::gpu_deflate::huffman::code
-  {
-    return static_cast<::gpu_deflate::huffman::code>(*this);
-  }
+  constexpr explicit encoding(symbol_type s, code c) : code{c}, symbol{s} {}
 
   friend auto
   operator<<(std::ostream& os, const encoding& point) -> std::ostream&
   {
-    os << +point.bitsize        //
-       << "\t" << point.code()  //
-       << "\t" << point.value   //
+    os << +point.bitsize                           //
+       << "\t" << static_cast<const code&>(point)  //
+       << "\t" << point.value                      //
        << "\t`" << point.symbol << '`';
 
     return os;

--- a/huffman/test/BUILD.bazel
+++ b/huffman/test/BUILD.bazel
@@ -1,6 +1,15 @@
 load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_test")
 
 cc_test(
+    name = "bit_test",
+    srcs = ["bit_test.cpp"],
+    deps = [
+        "//huffman",
+        "@boost_ut",
+    ],
+)
+
+cc_test(
     name = "code_test",
     srcs = ["code_test.cpp"],
     deps = [

--- a/huffman/test/bit_test.cpp
+++ b/huffman/test/bit_test.cpp
@@ -1,0 +1,58 @@
+#include "huffman/huffman.hpp"
+
+#include <boost/ut.hpp>
+
+#include <concepts>
+#include <cstddef>
+#include <cstdint>
+#include <sstream>
+
+auto main() -> int
+{
+  using ::boost::ut::aborts;
+  using ::boost::ut::expect;
+  using ::boost::ut::test;
+
+  namespace huffman = ::gpu_deflate::huffman;
+  using namespace huffman::literals;
+
+  test("bit is truthy") = [] {
+    expect(not huffman::bit{0});
+    expect(bool(huffman::bit{1}));
+  };
+
+  test("bit is constructible with literal") = [] {
+    expect(huffman::bit{0} == 0_b);
+    expect(huffman::bit{1} == 1_b);
+  };
+
+  test("bit is constructible from char") = [] {
+    expect(huffman::bit{'0'} == 0_b);
+    expect(huffman::bit{'1'} == 1_b);
+  };
+
+  test("bit is constructible from bool") = [] {
+    expect(huffman::bit{false} == 0_b);
+    expect(huffman::bit{true} == 1_b);
+  };
+
+  test("bit is ostreamable") = [] {
+    {
+      auto ss = std::stringstream{};
+      ss << 0_b;
+      expect(ss.str() == "0");
+    }
+
+    {
+      auto ss = std::stringstream{};
+      ss << 1_b;
+      expect(ss.str() == "1");
+    }
+  };
+
+  test("bit aborts if constructed with out of range value") = [] {
+    expect(aborts([] { huffman::bit{-1}; }));
+    expect(aborts([] { huffman::bit{2}; }));
+    expect(aborts([] { huffman::bit{'2'}; }));
+  };
+}


### PR DESCRIPTION
Define a distinct `bit` type, allowing strongly-typed bit operations on
`code` values.

`code::bit_view()` now returns of range of `bit` types instead of chars.

Change-Id: Iea9328d01d92a5b513c3644a442ceafa3f2ac89e