### PR TITLE
Allow construction of a `table` from code-symbol map

### DIFF
--- a/huffman/src/detail/static_vector.hpp
+++ b/huffman/src/detail/static_vector.hpp
@@ -41,6 +41,20 @@ public:
     }
   }
 
+  constexpr auto resize(size_type new_cap) -> void
+  {
+    reserve(new_cap);
+
+    if (size() < new_cap) {
+      const auto first = begin() + size();
+      std::for_each(first, first + (new_cap - size()), [](auto& elem) {
+        elem = {};
+      });
+    }
+
+    size_ = new_cap;
+  }
+
   template <class... Args>
   constexpr auto emplace_back(Args&&... args) -> reference
   {

--- a/huffman/src/detail/table_node.hpp
+++ b/huffman/src/detail/table_node.hpp
@@ -41,7 +41,7 @@ namespace gpu_deflate::huffman::detail {
 /// obtained the underlying `encoding` for each element.
 ///
 template <class Symbol>
-class table_node : encoding<Symbol>
+class table_node : public encoding<Symbol>
 {
   std::size_t frequency_{};
   std::size_t node_size_{};
@@ -63,21 +63,6 @@ public:
   constexpr auto frequency() const { return frequency_; }
 
   constexpr auto node_size() const { return node_size_; }
-
-  /// Obtain the underlying `encoding` for this node
-  ///
-  /// @{
-
-  constexpr auto base() -> encoding_type&
-  {
-    return static_cast<encoding_type&>(*this);
-  }
-  constexpr auto base() const -> const encoding_type&
-  {
-    return static_cast<const encoding_type&>(*this);
-  }
-
-  /// @}
 
   /// Obtains the next node, with respect to node size
   ///
@@ -137,7 +122,7 @@ public:
       return cmp;
     }
 
-    return lhs.base().symbol <=> rhs.base().symbol;
+    return lhs.symbol <=> rhs.symbol;
   }
 
   [[nodiscard]]

--- a/huffman/test/BUILD.bazel
+++ b/huffman/test/BUILD.bazel
@@ -36,6 +36,15 @@ cc_test(
     ],
 )
 
+cc_test(
+    name = "table_from_contents_test",
+    srcs = ["table_from_contents_test.cpp"],
+    deps = [
+        "//huffman",
+        "@boost_ut",
+    ],
+)
+
 cc_binary(
     name = "bench",
     srcs = ["bench.cpp"],

--- a/huffman/test/table_from_contents_test.cpp
+++ b/huffman/test/table_from_contents_test.cpp
@@ -1,0 +1,162 @@
+#include "huffman/huffman.hpp"
+
+#include <boost/ut.hpp>
+
+#include <algorithm>
+#include <tuple>
+#include <utility>
+#include <vector>
+
+auto main() -> int
+{
+  using ::boost::ut::aborts;
+  using ::boost::ut::expect;
+  using ::boost::ut::test;
+
+  namespace huffman = ::gpu_deflate::huffman;
+  using namespace huffman::literals;
+
+  test("code table constructible from code-symbol mapping") = [] {
+    const auto t = huffman::table<char>{
+        huffman::table_contents,
+        {{00000_c, '\4'},
+         {00001_c, 'x'},
+         {0001_c, 'q'},
+         {001_c, 'n'},
+         {01_c, 'i'},
+         {1_c, 'e'}}};
+
+    auto ss = std::stringstream{};
+    ss << t;
+
+    constexpr auto table =
+        "Bits\tCode\tValue\tSymbol\n"
+        "1\t1\t1\t`e`\n"
+        "2\t01\t1\t`i`\n"
+        "3\t001\t1\t`n`\n"
+        "4\t0001\t1\t`q`\n"
+        "5\t00000\t0\t`\4`\n"
+        "5\t00001\t1\t`x`\n";
+
+    expect(table == ss.str()) << ss.str();
+  };
+
+  test("code table constructible from code-symbol mapping from different "
+       "ranges") = [] {
+    // `t1` deduces a C-array for the range
+    const auto t1 =  // clang-format off
+      huffman::table<char>{
+        huffman::table_contents,
+        {{00000_c, '\4'},
+         {00001_c, 'x'},
+         {0001_c,  'q'},
+         {001_c,   'n'},
+         {01_c,    'i'},
+         {1_c,     'e'}}
+      };
+    // clang-format on
+
+    const auto t2 =  // clang-format off
+      huffman::table<char>{
+        huffman::table_contents,
+        std::vector{
+            std::tuple{00000_c, '\4'},
+                      {00001_c, 'x'},
+                      {0001_c,  'q'},
+                      {001_c,   'n'},
+                      {01_c,    'i'},
+                      {1_c,     'e'}}
+      };
+    // clang-format on
+
+    expect(std::ranges::equal(t1, t2));
+  };
+
+  test("code table constructible from code-symbol mapping with deduction "
+       "guides") = [] {
+    const auto t1 =  // clang-format off
+      huffman::table{
+        huffman::table_contents,
+        {std::pair{00000_c, '\4'},
+                  {00001_c, 'x'},
+                  {0001_c,  'q'},
+                  {001_c,   'n'},
+                  {01_c,    'i'},
+                  {1_c,     'e'}}
+      };
+    // clang-format on
+
+    const auto t2 =  // clang-format off
+      huffman::table{
+        huffman::table_contents,
+        std::vector{
+            std::tuple{00000_c, '\4'},
+                      {00001_c, 'x'},
+                      {0001_c,  'q'},
+                      {001_c,   'n'},
+                      {01_c,    'i'},
+                      {1_c,     'e'}}
+      };
+      // clang-format off
+
+    expect(std::ranges::equal(t1, t2));
+  };
+
+  test("code table constexpr constructible from code-symbol") = [] {
+    static constexpr auto t1 = // clang-format off
+      huffman::table{
+        huffman::table_contents,
+        {std::pair{00000_c, '\4'},
+                  {00001_c, 'x'},
+                  {0001_c,  'q'},
+                  {001_c,   'n'},
+                  {01_c,    'i'},
+                  {1_c,     'e'}}
+      };
+    // clang-format on
+
+    static constexpr auto t2 =  // clang-format off
+        huffman::table<char, 6>{
+          huffman::table_contents,
+          {{00000_c, '\4'},
+           {00001_c, 'x'},
+           {0001_c,  'q'},
+           {001_c,   'n'},
+           {01_c,    'i'},
+           {1_c,     'e'}}
+        };
+    // clang-format on
+
+    expect(std::ranges::equal(t1, t2));
+  };
+
+  test("code table aborts on duplicate codes") = [] {
+    expect(aborts([] {  // clang-format off
+      huffman::table{
+          huffman::table_contents,
+          {std::pair{00000_c, '\4'},
+                    {00001_c, 'x'},
+                    {0001_c,  'q'},
+                    {0001_c,  'g'},
+                    {001_c,   'n'},
+                    {01_c,    'i'},
+                    {1_c,     'e'}}};
+      // clang-format on
+    }));
+  };
+
+  test("code table aborts on duplicate symbols") = [] {
+    expect(aborts([] {  // clang-format off
+      huffman::table{
+          huffman::table_contents,
+          {std::pair{00000_c, '\4'},
+                    {00001_c, 'x'},
+                    {0001_c,  'q'},
+                    {0000_c,  'q'},
+                    {001_c,   'n'},
+                    {01_c,    'i'},
+                    {1_c,     'e'}}};
+      // clang-format on
+    }));
+  };
+}


### PR DESCRIPTION
Define a constructor for `huffman::table` from an existing code-symbol
mapping:

  huffman::table<char>{
    huffman::mapping,
    {{00000_c, '\4'},
     {00001_c, 'x'},
     {0001_c,  'q'},
     {001_c,   'n'},
     {01_c,    'i'},
     {1_c,     'e'}};

This is primarily used in upcoming decoding tests. It avoids the need to
construct a table from data or frequencies and allows direct comparisons
to other Huffman decoding implementations.

Change-Id: If42c8d309eaab74fcdbfd5c68e51546eadac1e3f