### PR TITLE
Patch LLVM toolchain tools to use Bootlin sysroot libraries

### DIFF
--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -52,8 +52,6 @@ bootlin_toolchain(
     libc_impl = "glibc",
 )
 
-load("@gcc_12_2_toolchain//:sysroot_path.bzl", "SYSROOT_PATH")
-
 BAZEL_TOOLCHAIN_VERSION = "41ff2a05c0beff439bad7acfd564e6827e34b13b"
 
 http_archive(
@@ -63,10 +61,11 @@ http_archive(
     url = "https://github.com/grailbio/bazel-toolchain/archive/%s.tar.gz" % BAZEL_TOOLCHAIN_VERSION,
 )
 
-load("@bazel_toolchain//toolchain:deps.bzl", "bazel_toolchain_dependencies")
-load("@bazel_toolchain//toolchain:rules.bzl", "llvm_toolchain")
+load("//tools:llvm_toolchain_dependencies.bzl", "llvm_toolchain_dependencies")
 
-bazel_toolchain_dependencies()
+llvm_toolchain_dependencies()
+
+load("//tools:llvm_toolchain.bzl", "llvm_toolchain")
 
 llvm_toolchain(
     name = "llvm_16_0_toolchain",
@@ -83,23 +82,9 @@ llvm_toolchain(
     # https://github.com/grailbio/bazel-toolchain/blob/ceeedcc4464322e05fe5b8df3749cc02273ee083/toolchain/cc_toolchain_config.bzl#L148-L150
     link_libs = {
         "": ["--driver-mode=g++"],
-        "linux-x86_64": [
-            "-stdlib=libc++",
-            "--driver-mode=g++",
-        ] + [
-            opt.format(sysroot = SYSROOT_PATH)
-            for opt in [
-                "-Wl,--rpath={sysroot}/lib",
-                "-Wl,--rpath={sysroot}/usr/lib",
-                "-Wl,--rpath={sysroot}/../lib64",
-                "-Wl,--dynamic-linker={sysroot}/lib/ld-linux-x86-64.so.2",
-            ]
-        ],
     },
+    linux_x86_64_sysroot = "@gcc_12_2_toolchain_files//x86_64-buildroot-linux-gnu/sysroot",
     llvm_version = "16.0.0",
-    sysroot = {
-        "linux-x86_64": "@gcc_12_2_toolchain_files//x86_64-buildroot-linux-gnu/sysroot",
-    },
 )
 
 # register llvm first, it has better error messages
@@ -150,11 +135,11 @@ http_archive(
     url = "https://github.com/oliverlee/bazel_clang_format/archive/%s.tar.gz" % BAZEL_CLANG_FORMAT_VERSION,
 )
 
-BAZEL_CLANG_TIDY_VERSION = "ba5e6709229ac56f166326fedce99820da81ca4b"
+BAZEL_CLANG_TIDY_VERSION = "aae87699cca19d8f6e84538576ab47587043d1d2"
 
 http_archive(
     name = "bazel_clang_tidy",
-    sha256 = "7b71307778e69be250d548e66386776962b564cad29d748cf070adab899afe20",
+    sha256 = "ee7d89375b5c6554b40ea1b1132a8cf7e3e269f7c2f6b2f595e4c7181d44b736",
     strip_prefix = "bazel_clang_tidy-%s" % BAZEL_CLANG_TIDY_VERSION,
     url = "https://github.com/oliverlee/bazel_clang_tidy/archive/%s.tar.gz" % BAZEL_CLANG_TIDY_VERSION,
 )

--- a/tools/llvm_toolchain.bzl
+++ b/tools/llvm_toolchain.bzl
@@ -1,0 +1,203 @@
+"""
+Provides a wrapper around `llvm_toolchain` that uses a package provided sysroot
+instead of the system installed libraries.
+"""
+
+load(
+    "@bazel_toolchain//toolchain:deps.bzl",
+    _llvm_toolchain_dependencies = "bazel_toolchain_dependencies",
+)
+load(
+    "@bazel_toolchain//toolchain:rules.bzl",
+    _llvm_toolchain = "llvm_toolchain",
+    _llvm_toolchain_files = "llvm",
+)
+load("@local_config_info//:defs.bzl", "BAZEL_EXTERNAL_DIR")
+
+#  Rename to (hopefully) be less confusing
+llvm_toolchain_dependencies = _llvm_toolchain_dependencies
+
+def _patch_dynamic_linker_impl(rctx):
+    label = Label(rctx.attr.base_workspace + ":BUILD.bazel")
+    base_workspace = str(rctx.path(label).realpath).removesuffix("/BUILD.bazel")
+    this_workspace = str(rctx.path("."))
+
+    files = rctx.execute(
+        ["ls", base_workspace],
+    ).stdout.replace("WORKSPACE", "").replace("bin", "").strip().split("\n")
+
+    for f in files:
+        source = base_workspace + "/" + f
+        dest = this_workspace + "/" + f
+        rctx.execute(["ln", "-s", source, dest])
+
+    rctx.execute(["cp", "-r", base_workspace + "/bin", "real-bin"])
+
+    for tool in rctx.execute(["ls", "real-bin"]).stdout.strip().split("\n"):
+        rctx.file(
+            "bin/" + tool,
+            content = """#!/bin/bash
+            exec "{dynamic_linker}" --library-path "{paths}" "{real_tool}" "$@"
+            """.format(
+                dynamic_linker = rctx.attr.dynamic_linker,
+                paths = ":".join(rctx.attr.library_paths),
+                real_tool = this_workspace + "/real-bin/" + tool,
+            ),
+        )
+
+_patch_dynamic_linker = repository_rule(
+    implementation = _patch_dynamic_linker_impl,
+    attrs = {
+        "dynamic_linker": attr.string(
+            mandatory = True,
+            doc = """
+            Absolute path to an alternate dynamic linker.
+            """,
+        ),
+        "library_paths": attr.string_list(
+            mandatory = True,
+            doc = """
+            Absolute paths for the library search directories. These are used
+            along with the dynamic linker.
+            """,
+        ),
+        "base_workspace": attr.string(
+            mandatory = True,
+            doc = """
+            Base workspace containing binaries to patch.
+            """,
+        ),
+    },
+    doc = """
+    Copies the contents of `base_workspace` but replaces all files in the `bin`
+    directory with wrapper scripts. These wrapper scripts use the specified
+    `dynamic_linker`, allowing runtime use of libraries in `library_paths`.
+    """,
+)
+
+def _extend_linux_x86_64_key(arg_dict, values):
+    existing = arg_dict.get("linux-x86_64", arg_dict[""])
+    arg_dict["linux-x86_64"] = existing + values
+    return arg_dict
+
+def llvm_toolchain(linux_x86_64_sysroot = "", **kwargs):
+    # buildifier: disable=function-docstring-args
+    """
+    Wraps `llvm_toolchain`, forcing use of a user-provided sysroot on linux-x86_64.
+
+    Args:
+      linux_x86_64_sysroot: string
+        label of a sysroot
+
+    for other args, see
+    https://github.com/grailbio/bazel-toolchain/blob/master/toolchain/rules.bzl
+    """
+
+    if not linux_x86_64_sysroot:
+        fail("""
+        This rule requires the sysroot to be specified for linux-x86_64
+        platforms. If this not desired, use `llvm_toolchain` from
+        `@bazel_toolchain` directly.
+        """)
+
+    linux_x86_64_sysroot_pkg = linux_x86_64_sysroot
+    linux_x86_64_sysroot_path = (
+        BAZEL_EXTERNAL_DIR +
+        linux_x86_64_sysroot_pkg.replace("@", "/").replace("//", "/")
+    )
+
+    if "sysroot" in kwargs or "toolchain_roots" in kwargs:
+        fail("""
+        `sysroot` and `toolchain_roots` need to be overriden by
+        `llvm_toolchain`.
+        """)
+
+    _llvm_toolchain_files(
+        name = kwargs["name"] + "_files",
+        llvm_version = kwargs["llvm_version"],
+    )
+
+    _patch_dynamic_linker(
+        name = kwargs["name"] + "_patched_files",
+        dynamic_linker = linux_x86_64_sysroot_path + "/lib/ld-linux-x86-64.so.2",
+        library_paths = [
+            "{sysroot}/{path}".format(
+                sysroot = linux_x86_64_sysroot_path,
+                path = path,
+            )
+            for path in ["lib", "usr/lib"]
+        ],
+        base_workspace = "@{name}_files//".format(name = kwargs["name"]),
+    )
+
+    kwargs["sysroot"] = {
+        "linux-x86_64": linux_x86_64_sysroot_pkg,
+    }
+
+    kwargs["toolchain_roots"] = {
+        "": "@{files}//".format(
+            files = kwargs["name"] + "_files",
+        ),
+        "linux-x86_64": "@{patched_files}//".format(
+            patched_files = kwargs["name"] + "_patched_files",
+        ),
+    }
+
+    # https://github.com/bazelbuild/bazel/issues/4605
+    patched_files_abspath = (
+        BAZEL_EXTERNAL_DIR + "/" + kwargs["name"] + "_patched_files"
+    )
+
+    kwargs["link_libs"] = _extend_linux_x86_64_key(
+        kwargs.get("link_libs", {"": []}),
+        [
+            # libraries from llvm are statically linked and we don't want to
+            # dynamically link duplicates from sysroot
+            "-nostdlib++",
+            "-fuse-ld={patched_files_abspath}/bin/ld.lld".format(
+                patched_files_abspath = patched_files_abspath,
+            ),
+        ] + [
+            opt.format(sysroot = linux_x86_64_sysroot_path)
+            for opt in [
+                "-Wl,--rpath={sysroot}/lib",
+                "-Wl,--rpath={sysroot}/usr/lib",
+                "-Wl,--rpath={sysroot}/../lib64",
+                "-Wl,--dynamic-linker={sysroot}/lib/ld-linux-x86-64.so.2",
+            ]
+        ],
+    )
+
+    major_version = kwargs["llvm_version"].split(".")[0]
+    kwargs["cxx_builtin_include_directories"] = _extend_linux_x86_64_key(
+        kwargs.get("cxx_builtin_include_directories", {"": []}),
+        [
+            "{patched_files_abspath}/{include_dir}".format(
+                patched_files_abspath = patched_files_abspath,
+                include_dir = include_dir,
+            )
+            for include_dir in [
+                "/include/c++/v1",
+                "/include/x86_64-unknown-linux-gnu/c++/v1",
+                "/lib/clang/{}/include".format(major_version),
+                "/lib/clang/{}/share".format(major_version),
+            ]
+        ] + [
+            # The clang-tidy aspect won't find include directories in the sysroot unless we
+            # specify the abspath.
+            #
+            # These *must* be found after C++ standard library headers:
+            # https://github.com/llvm/llvm-project/commit/8cedff10a18d8eba9190a645626fa6a509c1f139
+            "{sysroot}/{include_dir}".format(
+                sysroot = linux_x86_64_sysroot_path,
+                include_dir = include_dir,
+            )
+            for include_dir in [
+                "include",
+                "usr/include",
+                "usr/local/include",
+            ]
+        ],
+    )
+
+    _llvm_toolchain(**kwargs)

--- a/tools/llvm_toolchain_dependencies.bzl
+++ b/tools/llvm_toolchain_dependencies.bzl
@@ -1,0 +1,12 @@
+"""
+Provides a wrapper around `bazel_toolchain_dependencies` which also obtains the
+abspath to Bazel's external directory for use by the `llvm_toolchain` wrapper.
+"""
+
+load("@bazel_toolchain//toolchain:deps.bzl", "bazel_toolchain_dependencies")
+load("//tools:local_config_info.bzl", "local_config_info")
+
+#  Rename to (hopefully) be less confusing
+def llvm_toolchain_dependencies():
+    bazel_toolchain_dependencies()
+    local_config_info(name = "local_config_info")

--- a/tools/local_config_info.bzl
+++ b/tools/local_config_info.bzl
@@ -1,0 +1,20 @@
+"""
+Repository rule for determining Bazel directories.
+"""
+
+def _local_config_info_impl(rctx):
+    rctx.file("BUILD.bazel")
+
+    external = str(rctx.path(".").realpath).removesuffix("/" + rctx.name)
+
+    rctx.file(
+        "defs.bzl",
+        executable = False,
+        content = """BAZEL_EXTERNAL_DIR = "{}"
+              """.format(external),
+    )
+
+local_config_info = repository_rule(
+    implementation = _local_config_info_impl,
+    doc = "A repository rule for determining Bazel directories",
+)


### PR DESCRIPTION
Wrap all tools from LLVM, replacing the dynamic loader with one from the
Bootlin toolchain sysroot. This allows use of Bootlin provided libraries
instead of relying on system libraries of the host (e.g. libc).

This commit updates @bazel_clang_tidy to add toolchain builtin include
directories to the ClangTidy command line.

Change-Id: I5369ee89d06004670f57df02d1bb745c44a6846c