### PR TITLE
Simplify toolchain names

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -5,7 +5,7 @@ build:clang16 --extra_toolchains=//toolchain:clang16
 build:gcc12   --extra_toolchains=//toolchain:gcc12
 
 build:clang-format --aspects @bazel_clang_format//:defs.bzl%clang_format_aspect
-build:clang-format --@bazel_clang_format//:binary=@llvm_16_0_toolchain//:clang-format
+build:clang-format --@bazel_clang_format//:binary=@llvm_16_toolchain//:clang-format
 build:clang-format --@bazel_clang_format//:config=//:format_config
 build:clang-format --output_groups=report
 build:clang-format --keep_going
@@ -20,7 +20,7 @@ build:verbose-clang-tidy --config=clang-tidy-base
 build:verbose-clang-tidy --@bazel_clang_tidy//:clang_tidy_executable=//tools:verbose-clang-tidy
 
 build:clang-tidy --config=clang-tidy-base
-build:clang-tidy --@bazel_clang_tidy//:clang_tidy_executable=@llvm_16_0_toolchain//:clang-tidy
+build:clang-tidy --@bazel_clang_tidy//:clang_tidy_executable=@llvm_16_toolchain//:clang-tidy
 
 try-import %workspace%/user.bazelrc
 

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,5 +8,5 @@
         "--compile-commands-dir=${workspaceFolder}/",
         "--query-driver=**"
     ],
-    "clangd.path": "${workspaceFolder}/bazel-gpu-deflate/external/llvm_16_0_toolchain_llvm/bin/clangd"
+    "clangd.path": "${workspaceFolder}/bazel-gpu-deflate/external/llvm_16_toolchain_llvm/bin/clangd"
 }

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -18,14 +18,14 @@ filegroup(
 
 clang_format_update(
     name = "clang-format",
-    binary = "@llvm_16_0_toolchain//:clang-format",
+    binary = "@llvm_16_toolchain//:clang-format",
     config = ":format_config",
 )
 
 clang_tidy_apply_fixes(
     name = "clang-tidy-fix",
-    apply_replacements_binary = "@llvm_16_0_toolchain//:clang-apply-replacements",
-    tidy_binary = "@llvm_16_0_toolchain//:clang-tidy",
+    apply_replacements_binary = "@llvm_16_toolchain//:clang-apply-replacements",
+    tidy_binary = "@llvm_16_toolchain//:clang-tidy",
     tidy_config = ":tidy_config",
 )
 

--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -38,7 +38,7 @@ COMMON_CXX_WARNINGS = [
 # see https://toolchains.bootlin.com/releases_x86-64.html
 #
 bootlin_toolchain(
-    name = "gcc_12_2_toolchain",
+    name = "gcc_12_toolchain",
     architecture = "x86-64",
     buildroot_version = "bleeding-edge-2022.08-1",
     extra_cxx_flags = [
@@ -68,7 +68,7 @@ llvm_toolchain_dependencies()
 load("//tools:llvm_toolchain.bzl", "llvm_toolchain")
 
 llvm_toolchain(
-    name = "llvm_16_0_toolchain",
+    name = "llvm_16_toolchain",
     cxx_flags = {
         "": [
             "-stdlib=libc++",
@@ -83,17 +83,17 @@ llvm_toolchain(
     link_libs = {
         "": ["--driver-mode=g++"],
     },
-    linux_x86_64_sysroot = "@gcc_12_2_toolchain_files//x86_64-buildroot-linux-gnu/sysroot",
+    linux_x86_64_sysroot = "@gcc_12_toolchain_files//x86_64-buildroot-linux-gnu/sysroot",
     llvm_version = "16.0.4",
 )
 
 # register llvm first, it has better error messages
-load("@llvm_16_0_toolchain//:toolchains.bzl", "llvm_register_toolchains")
+load("@llvm_16_toolchain//:toolchains.bzl", "llvm_register_toolchains")
 
 llvm_register_toolchains()
 
 register_toolchains(
-    "@gcc_12_2_toolchain//:toolchain",
+    "@gcc_12_toolchain//:toolchain",
 )
 
 BOOST_UT_VERSION = "e53a47d37bc594e80bd5f1b8dc1ade8dce4429d3"

--- a/toolchain/BUILD.bazel
+++ b/toolchain/BUILD.bazel
@@ -14,14 +14,14 @@ cc_binary(
 
 alias(
     name = "gcc12",
-    actual = "@gcc_12_2_toolchain//:toolchain",
+    actual = "@gcc_12_toolchain//:toolchain",
 )
 
 alias(
     name = "clang16",
     actual = select({
-        "@platforms//os:macos": "@llvm_16_0_toolchain//:cc-toolchain-aarch64-darwin",
-        "//conditions:default": "@llvm_16_0_toolchain//:cc-toolchain-x86_64-linux",
+        "@platforms//os:macos": "@llvm_16_toolchain//:cc-toolchain-aarch64-darwin",
+        "//conditions:default": "@llvm_16_toolchain//:cc-toolchain-x86_64-linux",
     }),
 )
 

--- a/tools/BUILD.bazel
+++ b/tools/BUILD.bazel
@@ -6,14 +6,14 @@ genrule(
     cmd = """
 echo "$$(dirname $@)/../$(rootpath {tidy}) --enable-check-profile \\$$@" > $@
 """.format(
-        tidy = "@llvm_16_0_toolchain//:clang-tidy",
+        tidy = "@llvm_16_toolchain//:clang-tidy",
     ),
     executable = True,
-    tools = ["@llvm_16_0_toolchain//:clang-tidy"],
+    tools = ["@llvm_16_toolchain//:clang-tidy"],
 )
 
 sh_binary(
     name = "verbose-clang-tidy",
     srcs = ["verbose-clang-tidy.sh"],
-    data = ["@llvm_16_0_toolchain//:clang-tidy"],
+    data = ["@llvm_16_toolchain//:clang-tidy"],
 )


### PR DESCRIPTION
Rename
 `llvm_16_0_toolchain` -> `llvm_16_toolchain` and
 `gcc_12_2_toolchain`  -> `gcc_12_2_toolchain`

until we decide we want to support different minor GCC or Clang
toolchain versions.

Change-Id: I5d1196bdf9d990764034775f558d2d14e413758d
Co-authored-by: Gary Miguel <garymm@garymm.org>