### PR TITLE
Change UBSan linkopt flag

### DIFF
--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -81,7 +81,7 @@ llvm_toolchain(
     # use `link_libs` to prevent overriding default `link_flags`
     # https://github.com/grailbio/bazel-toolchain/blob/ceeedcc4464322e05fe5b8df3749cc02273ee083/toolchain/cc_toolchain_config.bzl#L148-L150
     link_libs = {
-        "": ["--driver-mode=g++"],
+        "": ["-fsanitize-link-c++-runtime"],
     },
     linux_x86_64_sysroot = "@gcc_12_toolchain_files//x86_64-buildroot-linux-gnu/sysroot",
     llvm_version = "16.0.4",


### PR DESCRIPTION
Both `-fsanitize-link-c++-runtime` and `--driver-mode=g++` can be used to
work around https://github.com/bazelbuild/bazel/issues/12797
but intent is clearer with `-fsanitize-link-c++-runtime`.

resolves #57

Change-Id: I8bbf9518b7587f67c274ed389e5153d66166b2f7