### PR TITLE
rm build-without-terminfo GitHub checks

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -77,29 +77,6 @@ jobs:
           ${{ matrix.flag }} \
           //...
 
-  build-without-terminfo:
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        toolchain: [gcc, clang]
-
-    steps:
-    - uses: actions/checkout@v3
-
-    - name: mount bazel cache
-      uses: actions/cache@v3
-      with:
-        path: "~/.cache/bazel"
-        key: bazel-build-without-terminfo-${{ matrix.toolchain }}
-
-    - run: |
-        bazel \
-          --bazelrc=.github/workflows/ci.bazelrc \
-          build \
-          --config=${{ matrix.toolchain }} \
-          //...
-
   buildifier:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
GitHub is throttling our jobs because we have so many. These seem like
the least important.

Change-Id: I8df8d538d303e3868d83f322002555ab20557f8f