### PR TITLE
define a container for reading bytes from a file

### DIFF
--- a/huffman/test/bit_span_test.cpp
+++ b/huffman/test/bit_span_test.cpp
@@ -13,6 +13,7 @@
 auto main() -> int
 {
   using ::boost::ut::aborts;
+  using ::boost::ut::eq;
   using ::boost::ut::expect;
   using ::boost::ut::test;
 
@@ -29,6 +30,12 @@ auto main() -> int
         expected | std::views::transform([](char c) {
           return huffman::bit{c};
         })));
+  };
+
+  test("default constructible") = [] {
+    constexpr auto bits = huffman::bit_span{};
+
+    expect(eq(0, bits.size()));
   };
 
   test("indexable") = [] {
@@ -113,6 +120,21 @@ auto main() -> int
       expect(aborts([&] { bits.consume(n); }));
     }
   } | std::views::iota(0UZ, 2UZ * (CHAR_BIT + 1UZ));
+
+  test("consume returns reference") = [] {
+    static constexpr auto data = std::byte{};
+
+    constexpr auto consumed_size = [] {
+      auto bits = huffman::bit_span{&data, CHAR_BIT};
+      return bits.consume(1).size();
+    }();
+
+    expect(eq(CHAR_BIT - 1, consumed_size));
+
+    constexpr auto consumed_bits =
+        huffman::bit_span{&data, CHAR_BIT}.consume(1);
+    expect(eq(CHAR_BIT - 1, consumed_bits.size()));
+  };
 
   test("consume_to_byte_boundary") = [] {
     static constexpr auto data = huffman::byte_array(0b10101010, 0b01010101);

--- a/src/test/BUILD.bazel
+++ b/src/test/BUILD.bazel
@@ -1,4 +1,20 @@
-load("@rules_cc//cc:defs.bzl", "cc_test")
+load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
+
+cc_library(
+    name = "byte_container",
+    testonly = True,
+    hdrs = ["byte_container.hpp"],
+)
+
+cc_test(
+    name = "byte_container_test",
+    timeout = "short",
+    srcs = ["byte_container_test.cpp"],
+    deps = [
+        ":byte_container",
+        "//:boost_ut",
+    ],
+)
 
 cc_test(
     name = "decompress_test",
@@ -7,6 +23,5 @@ cc_test(
     deps = [
         "//:boost_ut",
         "//src:decompress",
-        "@boost_ut",
     ],
 )

--- a/src/test/byte_container.hpp
+++ b/src/test/byte_container.hpp
@@ -1,0 +1,139 @@
+#pragma once
+
+#include <algorithm>
+#include <cassert>
+#include <concepts>
+#include <cstddef>
+#include <fstream>
+#include <ios>
+#include <iterator>
+#include <ranges>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+namespace starflate {
+namespace test {
+
+/// Container of bytes that allows `std::byte`-based traversal
+/// @tparam Container underlying byte storage container
+///
+/// `byte_container` is a container type that allows iteration over a range of
+/// `std::byte` values. Constructors handle conversion of input ranges of `char`
+/// values to `std::byte` values.
+///
+template <std::ranges::contiguous_range Container>
+  requires std::same_as<std::byte, std::ranges::range_value_t<Container>>
+class byte_container
+    : public std::ranges::view_interface<byte_container<Container>>
+{
+  Container storage_;
+
+  static constexpr auto byte_view = std::views::transform([](auto c) {
+    return static_cast<std::byte>(c);
+  });
+
+public:
+  using container_type = Container;
+
+  /// Construct a bit container from a file
+  /// @tparam FsPath filename type
+  /// @tparam Args args forwarded to construct container_type
+  /// @param filename name of file to be opened
+  /// @param container_args args forwarded to the underlying container
+  /// constructor
+  ///
+  /// Opens a file specified by `filename` and reads its contents into the
+  /// underlying container.
+  ///
+  /// @pre `container_type{std::forward<Args>(container_args)...}.empty()` is
+  /// `true`
+  ///
+  /// @see https://en.cppreference.com/w/cpp/io/basic_ifstream/basic_ifstream
+  ///
+  template <class FsPath, class... Args>
+    requires std::constructible_from<std::ifstream, FsPath&&> and
+             std::constructible_from<Container, Args&&...>
+  byte_container(FsPath&& filename, Args&&... container_args)
+      : storage_{std::forward<Args>(container_args)...}
+  {
+    assert(
+        storage_.empty() and
+        "underlying container must be empty before "
+        "reading input file");
+
+    auto input = std::ifstream{
+        filename,
+        std::ios_base::in | std::ios_base::binary | std::ios_base::ate};
+    if (not input.is_open()) {
+      using namespace std::string_literals;
+      throw std::runtime_error{"unable to open: "s + filename};
+    }
+
+    auto size = input.tellg();
+    assert(size >= 0);
+    storage_.reserve(static_cast<std::size_t>(size));
+    input.seekg(0);
+
+    const auto bytes =
+        std::ranges::subrange{
+            std::istreambuf_iterator<char>{input},
+            std::istreambuf_iterator<char>{}} |
+        byte_view;
+
+    // GCC doesn't define append_range yet
+    std::ranges::copy(bytes, std::back_inserter(storage_));
+  }
+
+  /// Construct from a string-like
+  ///
+  template <class... Args>
+    requires std::constructible_from<Container, Args&&...>
+  explicit byte_container(
+      std::in_place_t, std::string_view s, Args&&... container_args)
+      : storage_{std::forward<Args>(container_args)...}
+  {
+    assert(
+        storage_.empty() and
+        "underlying container must be empty before "
+        "reading setting bytes");
+
+    storage_.reserve(static_cast<std::size_t>(s.size()));
+
+    std::ranges::copy(s | byte_view, std::back_inserter(storage_));
+  }
+
+  /// Access the underlying storage container
+  ///
+  /// {@
+
+  [[nodiscard]]
+  auto underlying() const& -> const container_type&
+  {
+    return storage_;
+  }
+  [[nodiscard]]
+  auto underlying() && -> container_type&&
+  {
+    return std::move(storage_);
+  }
+
+  /// @}
+
+  [[nodiscard]]
+  auto begin() const -> decltype(storage_.begin())
+  {
+    return storage_.begin();
+  }
+  [[nodiscard]]
+  auto end() const -> decltype(storage_.end())
+  {
+    return storage_.end();
+  }
+};
+
+using byte_vector = byte_container<std::vector<std::byte>>;
+
+}  // namespace test
+}  // namespace starflate

--- a/src/test/byte_container_test.cpp
+++ b/src/test/byte_container_test.cpp
@@ -1,0 +1,87 @@
+#include "src/test/byte_container.hpp"
+
+#include "boost/ut.hpp"
+
+#include <algorithm>
+#include <array>
+#include <concepts>
+#include <cstddef>
+#include <fstream>
+#include <ios>
+#include <iostream>
+#include <ranges>
+#include <string>
+#include <string_view>
+#include <tuple>
+#include <utility>
+
+namespace test {
+
+template <class FsPath, std::ranges::contiguous_range Range>
+  requires std::same_as<std::byte, std::ranges::range_value_t<Range>>
+auto write_file(FsPath&& filename, const Range& data) -> void
+{
+  auto out = std::ofstream{
+      std::forward<FsPath>(filename), std::ios::binary | std::ios::trunc};
+
+  std::copy(
+      reinterpret_cast<const char*>(std::ranges::cbegin(data)),
+      reinterpret_cast<const char*>(std::ranges::cend(data)),
+      std::ostreambuf_iterator<char>{out});
+}
+
+}  // namespace test
+
+auto main() -> int
+{
+  using ::boost::ut::eq;
+  using ::boost::ut::expect;
+  using ::boost::ut::range_eq;
+  using ::boost::ut::test;
+  using ::boost::ut::operators::operator|;
+
+  static constexpr auto data =
+      std::array{std::byte{0}, std::byte{1}, std::byte{2}, std::byte{3}};
+
+  test("write then read file") = [] {
+    constexpr auto filename = "testfile1";
+
+    ::test::write_file(filename, data);
+
+    auto in = std::ifstream{filename, std::ios::binary};
+    auto inbuf = std::array<std::byte, 4>{};
+
+    std::copy(
+        std::istreambuf_iterator<char>{in},
+        std::istreambuf_iterator<char>{},
+        reinterpret_cast<char*>(inbuf.begin()));
+
+    expect(eq(inbuf, data));
+  };
+
+  test("write then read file") = [] {
+    constexpr auto filename = "testfile2";
+
+    ::test::write_file(filename, data);
+
+    const auto bytes = starflate::test::byte_vector{filename};
+
+    expect(range_eq(bytes, data));
+  };
+
+  {
+    static constexpr auto str = "abcd";
+
+    test("construct from string-like") = [](auto s) {
+      constexpr auto data1 = std::array{
+          static_cast<std::byte>('a'),
+          static_cast<std::byte>('b'),
+          static_cast<std::byte>('c'),
+          static_cast<std::byte>('d'),
+      };
+      const auto data2 = starflate::test::byte_vector{std::in_place, s};
+
+      expect(range_eq(data1, data2));
+    } | std::tuple{str, std::string{str}, std::string_view{str}};
+  }
+}

--- a/test_ut/test_ut_example.cpp
+++ b/test_ut/test_ut_example.cpp
@@ -1,13 +1,19 @@
 #include <boost/ut.hpp>
 
 #include <array>
+#include <cstddef>
 #include <ranges>
+#include <sstream>
 
 auto main() -> int
 {
+  using ::boost::ut::eq;
   using ::boost::ut::expect;
   using ::boost::ut::range_eq;
   using ::boost::ut::test;
+
+  // all of these tests are intended to fail in order to demonstrate information
+  // printed on test failure
 
   test("test range eq, lhs smaller") = [] {
     constexpr auto data1 = std::array{1, 2, 3};
@@ -28,5 +34,20 @@ auto main() -> int
     constexpr auto data2 = std::views::iota(1, 4);
 
     expect(range_eq(data1, data2));
+  };
+
+  test("print byte") = [] {
+    constexpr auto expected = "01100000";
+
+    const auto actual = (std::stringstream{} << std::byte{0b1110'0000}).str();
+
+    expect(eq(expected, actual));
+  };
+
+  test("print byte array") = [] {
+    constexpr auto data1 = std::array{std::byte{0xDEU}, std::byte{0xADU}};
+    constexpr auto data2 = std::array{std::byte{0xBEU}, std::byte{0xEFU}};
+
+    expect(eq(data1, data2));
   };
 }


### PR DESCRIPTION
Define a `byte_container` class template for use in tests. It provides
`std::byte`-oriented access (as opposed to `char`) to the bytes in a
file or string.

Change-Id: I364fcb0efaae9ac79bb78198912b885b3d9f54c5